### PR TITLE
Add infinity support

### DIFF
--- a/app/basicexport.cpp
+++ b/app/basicexport.cpp
@@ -24,6 +24,12 @@
 #include <iostream>
 #include <algorithm>
 
+namespace PMMLDocument
+{
+    extern const char* PMML_INFINITY;
+    extern bool hasInfinityValue;
+}
+
 namespace
 {
 // Take a CSV input and a dataDictionary from a model and work out which columns can be inputted/verified
@@ -87,6 +93,16 @@ void PMMLExporter::addFunctionHeader(LuaOutputter & output, const std::vector<PM
         // Overflow variables are passed in as an array because they may contain input parameters.
         output.keyword("overflow");
         first = false;
+    }
+
+    if (PMMLDocument::hasInfinityValue)
+    {
+        if (!first)
+        {
+            output.comma();
+        }
+        first = false;
+        output.keyword(PMMLDocument::PMML_INFINITY);
     }
 
     for (const auto & input : inputColumns)

--- a/common/document.cpp
+++ b/common/document.cpp
@@ -32,10 +32,11 @@
 #include "luaconverter/luaconverter.hpp"
 #include "luaconverter/optimiser.hpp"
 
-#include <iostream>
-
 namespace PMMLDocument
 {
+    const char* PMML_INFINITY = "Infinity";
+    bool hasInfinityValue = false;
+
 namespace
 {
 bool parseDataDictionary(const AstBuilder & builder, const tinyxml2::XMLElement * dataDictionary, DataFieldVector & dataDictionaryOut)

--- a/model/predicate.cpp
+++ b/model/predicate.cpp
@@ -106,12 +106,9 @@ namespace
             if (strcmp(value, PMMLDocument::PMML_INFINITY) == 0)
             {
                 PMMLDocument::hasInfinityValue = true;
-                builder.constant("math.huge", builder.topNode().coercedType);
             }
-            else
-            {
-                builder.constant(value, builder.topNode().coercedType);
-            }            
+
+            builder.constant(value, builder.topNode().coercedType);
             builder.function(*operatorOut, 2);
         }
         else

--- a/model/predicate.cpp
+++ b/model/predicate.cpp
@@ -24,6 +24,12 @@
 #include <algorithm>
 #include <assert.h>
 
+namespace PMMLDocument
+{
+    extern const char* PMML_INFINITY;
+    extern bool hasInfinityValue;
+}
+
 namespace
 {
     // These two lists must be kept in sync and ordered
@@ -96,7 +102,16 @@ namespace
                 builder.parsingError("Missing parameter in SimplePredicate", node->GetLineNum());
                 return false;
             }
-            builder.constant(value, builder.topNode().coercedType);
+            
+            if (strcmp(value, PMMLDocument::PMML_INFINITY) == 0)
+            {
+                PMMLDocument::hasInfinityValue = true;
+                builder.constant("math.huge", builder.topNode().coercedType);
+            }
+            else
+            {
+                builder.constant(value, builder.topNode().coercedType);
+            }            
             builder.function(*operatorOut, 2);
         }
         else


### PR DESCRIPTION
We have PMML models with Infinity as the value in predicates, like this:
```
<SimplePredicate field="someVarName" operator="lessOrEqual" value="Infinity"/>
```
Adding flag to enable creation of local "Infinity" variable to hold math.huge.