### PR TITLE
MLA-1520 - unify char treatment on aarch64 and x86_64

### DIFF
--- a/app/pamplemousse.cpp
+++ b/app/pamplemousse.cpp
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
     double epsilon = 0.0001;
     std::vector<PMMLExporter::ModelOutput> inputs;
     std::vector<PMMLExporter::ModelOutput> outputs;
-    int c;
+    int8_t c;
     
 #ifndef _WIN32
     while ((c = getopt_long(argc, argv, OPTSTRING, longopts, NULL)) != -1)

--- a/app/pamplemousse.cpp
+++ b/app/pamplemousse.cpp
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
     double epsilon = 0.0001;
     std::vector<PMMLExporter::ModelOutput> inputs;
     std::vector<PMMLExporter::ModelOutput> outputs;
-    char c;
+    int c;
     
 #ifndef _WIN32
     while ((c = getopt_long(argc, argv, OPTSTRING, longopts, NULL)) != -1)


### PR DESCRIPTION
As we're going to treat chars the same on aarch64 and x86_64, as unsigned values, replaced a char with int because of comparison to a negative value