### PR TITLE
MLA-1783 - fix for pmml2lua skipping decision trees

### DIFF
--- a/model/predicate.cpp
+++ b/model/predicate.cpp
@@ -137,7 +137,7 @@ namespace
         // Array is stored in space delimeted string, chop it up into potential variables while honouring quotations
         // and stick it into a Lua set: e.g. {["valuea"] = true, ["valueb"] = true}
         PMMLArrayIterator iterator(array->GetText());
-        for (; iterator.isValid(); ++iterator)
+        for (; iterator.hasMore(); ++iterator)
         {
             builder.constant(iterator.stringStart(), iterator.stringEnd() - iterator.stringStart(), fieldType);
             nArgs++;

--- a/model/predicate.hpp
+++ b/model/predicate.hpp
@@ -36,6 +36,7 @@ public:
     PMMLArrayIterator & operator++();
     PMMLArrayIterator operator++(int);
     bool isValid() const { return m_upto != m_stringStart; }
+    bool hasMore() const { return m_upto < m_endPtr; }
     bool hasUnterminatedQuote() const { return m_hasUnterminatedQuote; }
     const char * stringStart() const { return m_stringStart; }
     const char * stringEnd() const { return m_upto; }


### PR DESCRIPTION
Fix for pmml2lua skipping decision trees when there is an empty string in it