### PR TITLE
MLA-2427 - fix for pmml2lua converter producing incorrect splits

### DIFF
--- a/model/predicate.hpp
+++ b/model/predicate.hpp
@@ -36,7 +36,12 @@ public:
     PMMLArrayIterator & operator++();
     PMMLArrayIterator operator++(int);
     bool isValid() const { return m_upto != m_stringStart; }
-    bool hasMore() const { return m_upto < m_endPtr; }
+    bool hasMore() const
+    {
+        bool stringNotEmpty = m_stringStart != m_upto;
+        bool more = m_upto < m_endPtr || (stringNotEmpty && m_upto <= m_endPtr);
+        return more;
+    }
     bool hasUnterminatedQuote() const { return m_hasUnterminatedQuote; }
     const char * stringStart() const { return m_stringStart; }
     const char * stringEnd() const { return m_upto; }


### PR DESCRIPTION
Fix for pmml2lua converter dropping the last element of an array when producing splits