### PR TITLE
 Independent unit tests + defaultChild-as-else tree optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ if (NOT DEFINED skip_tests)
         unit_tests/test_function.cpp
         unit_tests/test_miningmodel.cpp
         unit_tests/test_naivebayes.cpp
+        unit_tests/test_pmmldocumentdefs.cpp
         unit_tests/test_predicate.cpp
         unit_tests/test_ruleset.cpp
         unit_tests/test_scorecard.cpp

--- a/model/treemodel.cpp
+++ b/model/treemodel.cpp
@@ -82,7 +82,39 @@ namespace
         
         const char * defaultChildID = node->Attribute("defaultChild");
         bool foundDefaultChild = false;
-        
+
+        // If `defaultChild` is the LAST sibling AND missing-value-strategy is
+        // defaultChild, we can elide its predicate entirely and emit its body
+        // as the trailing `else` of the if-chain. The default child's
+        // OR-with-missing-clauses predicate is mathematically equivalent to
+        // "everything the strict preceding siblings rejected" when those
+        // siblings' predicates are mutually exclusive partitions of the
+        // input space (which is the case for binary tree splits).
+        //
+        // Gated off when missingValuePenalty is set: the penalty path
+        // (lines below) uses the default child's predicate to build the
+        // penalty conditional, so we can't elide it without restructuring
+        // that path too.
+        bool defaultChildIsLastSibling = false;
+        if (config.missingValueStrategy == MVS_DEFAULTCHILD && defaultChildID && !config.missingValuePenalty)
+        {
+            const tinyxml2::XMLElement * lastChild = nullptr;
+            for (const tinyxml2::XMLElement * c = firstChildNode; c; c = c->NextSiblingElement("Node"))
+            {
+                lastChild = c;
+            }
+            if (lastChild)
+            {
+                if (const char * lastID = lastChild->Attribute("id"))
+                {
+                    if (strcmp(lastID, defaultChildID) == 0)
+                    {
+                        defaultChildIsLastSibling = true;
+                    }
+                }
+            }
+        }
+
         size_t ifChainSize = 0;
 
         std::vector<AstNode> savedPredicatesForNotFound;
@@ -90,6 +122,7 @@ namespace
         {
             const char * thisID = childNode->Attribute("id");
             bool isDefaultChild = config.missingValueStrategy == MVS_DEFAULTCHILD && defaultChildID && thisID && strcmp(thisID, defaultChildID) == 0;
+            const bool elideAsElse = isDefaultChild && defaultChildIsLastSibling;
             
             const tinyxml2::XMLElement * predicate = PMMLDocument::skipExtensions(childNode->FirstChildElement());
             if (predicate == nullptr)
@@ -174,7 +207,16 @@ namespace
                 builder.block(2);
             }
             
-            // Add predicate
+            // Add predicate (skipped for the default-as-last optimisation,
+            // in which case this child becomes the trailing else of the
+            // if-chain and needs no predicate of its own).
+            if (elideAsElse)
+            {
+                ifChainSize += 1;  // Body only.
+                foundDefaultChild = true;
+                continue;
+            }
+
             builder.pushNode(predicateNode);
             ifChainSize += 2;  // One for the body, one for the predicate.
             

--- a/unit_tests/test_pmmldocumentdefs.cpp
+++ b/unit_tests/test_pmmldocumentdefs.cpp
@@ -1,0 +1,98 @@
+//  Copyright 2018-2020 Lexis Nexis Risk Solutions
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Coverage for the small string -> enum converters in
+// common/pmmldocumentdefs.{cpp,hpp}. The optypeFromString and
+// outlierTreatmentFromString converters use std::equal_range over hand-sorted
+// const arrays, which silently returns an empty range if the array is not
+// actually sorted - so a maintenance mistake (inserting a new entry out of
+// alphabetical order) would make a known-valid input parse to INVALID with no
+// error or warning. The tests here lock down both the value mapping and the
+// sortedness invariant.
+
+#include "Cuti.h"
+
+#include "pmmldocumentdefs.hpp"
+
+#include <cstring>
+
+TEST_CLASS (TestPMMLDocumentDefs)
+{
+public:
+    void testDataTypeFromString()
+    {
+        using namespace PMMLDocument;
+
+        // Numeric variants - all of these are PMML 4.4 dataType values that
+        // should collapse to TYPE_NUMBER. Listed in the order they appear in
+        // the strcmp chain to make missed updates easy to spot.
+        const char * const numericNames[] = {
+            "double", "float",
+            "long", "int", "integer", "short",
+            "byte", "unsignedLong", "unsignedInt",
+            "unsignedShort", "unsignedByte"
+        };
+        for (const char * name : numericNames)
+        {
+            CPPUNIT_ASSERT_EQUAL_MESSAGE(name, TYPE_NUMBER, dataTypeFromString(name));
+        }
+
+        CPPUNIT_ASSERT_EQUAL(TYPE_BOOL,   dataTypeFromString("boolean"));
+        CPPUNIT_ASSERT_EQUAL(TYPE_STRING, dataTypeFromString("string"));
+
+        // Unknown / empty / case-sensitive-mismatch all map to TYPE_INVALID.
+        CPPUNIT_ASSERT_EQUAL(TYPE_INVALID, dataTypeFromString(""));
+        CPPUNIT_ASSERT_EQUAL(TYPE_INVALID, dataTypeFromString("Double"));   // wrong case
+        CPPUNIT_ASSERT_EQUAL(TYPE_INVALID, dataTypeFromString("nonsense"));
+    }
+
+    void testOpTypeFromString()
+    {
+        using namespace PMMLDocument;
+
+        // Every PMML optype value must round-trip to the matching enum.
+        // optypeFromString uses equal_range over a sorted name array, so this
+        // test also implicitly verifies the array is still sorted: if the
+        // array is mis-ordered, equal_range returns an empty range and the
+        // assertion fails.
+        CPPUNIT_ASSERT_EQUAL(OPTYPE_CATEGORICAL, optypeFromString("categorical"));
+        CPPUNIT_ASSERT_EQUAL(OPTYPE_CONTINUOUS,  optypeFromString("continuous"));
+        CPPUNIT_ASSERT_EQUAL(OPTYPE_ORDINAL,     optypeFromString("ordinal"));
+
+        CPPUNIT_ASSERT_EQUAL(OPTYPE_INVALID, optypeFromString(""));
+        CPPUNIT_ASSERT_EQUAL(OPTYPE_INVALID, optypeFromString("Categorical"));   // wrong case
+        CPPUNIT_ASSERT_EQUAL(OPTYPE_INVALID, optypeFromString("nominal"));
+    }
+
+    void testOutlierTreatmentFromString()
+    {
+        using namespace PMMLDocument;
+
+        // Same shape as OpType: equal_range over a sorted name array. Tests
+        // both the value mapping and (implicitly) the sortedness invariant.
+        CPPUNIT_ASSERT_EQUAL(OUTLIER_TREATMENT_AS_EXTREME_VALUES, outlierTreatmentFromString("asExtremeValues"));
+        CPPUNIT_ASSERT_EQUAL(OUTLIER_TREATMENT_AS_IS,             outlierTreatmentFromString("asIs"));
+        CPPUNIT_ASSERT_EQUAL(OUTLIER_TREATMENT_AS_MISSING_VALUES, outlierTreatmentFromString("asMissingValues"));
+
+        CPPUNIT_ASSERT_EQUAL(OUTLIER_TREATMENT_INVALID, outlierTreatmentFromString(""));
+        CPPUNIT_ASSERT_EQUAL(OUTLIER_TREATMENT_INVALID, outlierTreatmentFromString("AsIs"));   // wrong case
+        CPPUNIT_ASSERT_EQUAL(OUTLIER_TREATMENT_INVALID, outlierTreatmentFromString("clip"));
+    }
+
+    CPPUNIT_TEST_SUITE(TestPMMLDocumentDefs);
+    CPPUNIT_TEST(testDataTypeFromString);
+    CPPUNIT_TEST(testOpTypeFromString);
+    CPPUNIT_TEST(testOutlierTreatmentFromString);
+    CPPUNIT_TEST_SUITE_END();
+};

--- a/unit_tests/test_predicate.cpp
+++ b/unit_tests/test_predicate.cpp
@@ -770,6 +770,118 @@ public:
         CPPUNIT_ASSERT_EQUAL(false, executeSimpleQuery(L, "test", "model_year", nullptr));
     }
 
+    // Regression test for MLA-1783 (commit 157b486): an empty quoted string
+    // ("") at the start of a SimpleSetPredicate array used to cause the entire
+    // array to be discarded, because the iterator's old isValid() check
+    // (m_upto != m_stringStart) was false after parsing "" (both pointers end
+    // up at the closing quote). The fix swapped the loop termination check
+    // from isValid() to hasMore() in model/predicate.cpp, which uses
+    // m_upto < m_endPtr (and now also handles barewords-at-end via MLA-2427).
+    //
+    // Without the fix: the generated Lua set is empty, so isIn always returns
+    // false, including for the non-empty value "alpha" that follows.
+    void testSimpleSetWithLeadingEmptyString()
+    {
+        std::stringstream mystream;
+        Analyser::AnalyserContext analyserContext;
+        Analyser::NonNoneAssertionStackGuard nonnullassertions(analyserContext);
+
+        tinyxml2::XMLDocument document;
+        document.Parse("<SimpleSetPredicate field=\"category\" booleanOperator=\"isIn\">"
+                       "<Array n=\"3\" type=\"string\">&quot;&quot; &quot;alpha&quot; &quot;beta&quot;</Array>"
+                       "</SimpleSetPredicate>");
+        LuaOutputter outputter(mystream);
+        outputter.keyword("function test() return");
+        AstBuilder astBuilder;
+
+        PMMLDocument::ScopedVariableDefinitionStackGuard scope(astBuilder.context());
+        auto field = scope.addDataField("category", PMMLDocument::TYPE_STRING, PMMLDocument::ORIGIN_DATA_DICTIONARY, PMMLDocument::OPTYPE_CONTINUOUS);
+        astBuilder.context().addDefaultMiningField("category", field);
+
+        CPPUNIT_ASSERT_EQUAL(true, Predicate::parse(astBuilder, document.RootElement()));
+        LuaConverter::convertAstToLua(astBuilder.topNode(), outputter);
+        outputter.keyword("end");
+
+        lua_State * L = luaL_newstate();
+        if (luaL_dostring(L, mystream.str().c_str()))
+        {
+            std::string message = lua_tostring(L, -1);
+            CPPUNIT_ASSERT_MESSAGE(message, false);
+        }
+
+        // All three array entries should be in the set: the empty string and
+        // both later non-empty strings. Pre-fix, none of these matched.
+        CPPUNIT_ASSERT_EQUAL(true, executeSimpleQuery(L, "test", "category", ""));
+        CPPUNIT_ASSERT_EQUAL(true, executeSimpleQuery(L, "test", "category", "alpha"));
+        CPPUNIT_ASSERT_EQUAL(true, executeSimpleQuery(L, "test", "category", "beta"));
+        CPPUNIT_ASSERT_EQUAL(false, executeSimpleQuery(L, "test", "category", "gamma"));
+        CPPUNIT_ASSERT_EQUAL(false, executeSimpleQuery(L, "test", "category", nullptr));
+    }
+
+    // Regression test for MLA-2427 (commit 91ee2e0): the MLA-1783 fix used
+    // hasMore() = (m_upto < m_endPtr), which dropped the LAST element of any
+    // array whose final token is a bareword (unquoted), because such tokens
+    // leave m_upto sitting exactly at m_endPtr while m_stringStart still points
+    // inside the unread token. The follow-up fix added a clause:
+    //   m_upto <= m_endPtr && (m_stringStart != m_upto)
+    // so the last bareword is processed before termination.
+    //
+    // Without the fix: "78" is in the set but "80" is not, even though both
+    // are listed in the array. Quoted-string arrays don't trigger this bug
+    // because the closing quote sits before m_endPtr.
+    void testSimpleSetWithBarewordsAtEnd()
+    {
+        std::stringstream mystream;
+        Analyser::AnalyserContext analyserContext;
+        Analyser::NonNoneAssertionStackGuard nonnullassertions(analyserContext);
+
+        tinyxml2::XMLDocument document;
+        document.Parse("<SimpleSetPredicate field=\"year\" booleanOperator=\"isIn\">"
+                       "<Array n=\"3\" type=\"int\">70 78 80</Array>"
+                       "</SimpleSetPredicate>");
+        LuaOutputter outputter(mystream);
+        outputter.keyword("function test() return");
+        AstBuilder astBuilder;
+
+        PMMLDocument::ScopedVariableDefinitionStackGuard scope(astBuilder.context());
+        auto field = scope.addDataField("year", PMMLDocument::TYPE_NUMBER, PMMLDocument::ORIGIN_DATA_DICTIONARY, PMMLDocument::OPTYPE_CONTINUOUS);
+        astBuilder.context().addDefaultMiningField("year", field);
+
+        CPPUNIT_ASSERT_EQUAL(true, Predicate::parse(astBuilder, document.RootElement()));
+        LuaConverter::convertAstToLua(astBuilder.topNode(), outputter);
+        outputter.keyword("end");
+
+        lua_State * L = luaL_newstate();
+        if (luaL_dostring(L, mystream.str().c_str()))
+        {
+            std::string message = lua_tostring(L, -1);
+            CPPUNIT_ASSERT_MESSAGE(message, false);
+        }
+
+        // executeSimpleQuery pushes strings, but `year` is numeric so set
+        // membership is checked by number equality. Push numbers directly.
+        auto checkYear = [&](double yearValue) -> bool {
+            lua_pushnumber(L, yearValue);
+            lua_setglobal(L, "year");
+            lua_getglobal(L, "test");
+            if (lua_pcall(L, 0, 1, 0))
+            {
+                std::string message = lua_tostring(L, -1);
+                CPPUNIT_ASSERT_MESSAGE(message, false);
+            }
+            bool out = lua_toboolean(L, -1);
+            lua_pop(L, 1);
+            return out;
+        };
+
+        // All three array entries must match. The trailing "80" is the
+        // regression-critical one: pre-fix it was silently dropped.
+        CPPUNIT_ASSERT_EQUAL(true, checkYear(70));
+        CPPUNIT_ASSERT_EQUAL(true, checkYear(78));
+        CPPUNIT_ASSERT_EQUAL(true, checkYear(80));
+        CPPUNIT_ASSERT_EQUAL(false, checkYear(79));
+    }
+
     CPPUNIT_TEST_SUITE(TestPredicate);
     CPPUNIT_TEST(testSimplePredicate);
     CPPUNIT_TEST(testCompoundAndPredicate);
@@ -778,5 +890,7 @@ public:
     CPPUNIT_TEST(testMixedCompound);
     CPPUNIT_TEST(testSurrogate);
     CPPUNIT_TEST(testSimpleSet);
+    CPPUNIT_TEST(testSimpleSetWithLeadingEmptyString);
+    CPPUNIT_TEST(testSimpleSetWithBarewordsAtEnd);
     CPPUNIT_TEST_SUITE_END();
 };

--- a/unit_tests/test_tree.cpp
+++ b/unit_tests/test_tree.cpp
@@ -17,8 +17,9 @@
 #include "Cuti.h"
 
 #include "document.hpp"
-
 #include "testutils.hpp"
+
+#include <cstring>
 using namespace TestUtils;
 
 
@@ -174,6 +175,77 @@ public:
         lua_close(L);
     }
     
+    // Regression test for the tree codegen path where defaultChild is the
+    // LAST sibling of its parent. The existing testMissingValue case uses
+    // TreeMissingValue.pmml as-shipped, where defaultChild is the FIRST
+    // sibling at every internal node; that path is well exercised but the
+    // last-sibling case wasn't previously covered. Important now because we
+    // intend to start emitting last-sibling defaults as `else` (no predicate)
+    // rather than `elseif (negation)` for size/perf reasons.
+    void testMissingValueDefaultIsLastSibling()
+    {
+        tinyxml2::XMLDocument document;
+        CPPUNIT_ASSERT_EQUAL(tinyxml2::XML_SUCCESS,
+            document.LoadFile(getPathToFile("TreeMissingValue.pmml").c_str()));
+        tinyxml2::XMLElement * model = document.RootElement()->FirstChildElement("TreeModel");
+        setupIDOutput(document, model);
+        model->SetAttribute("missingValueStrategy", "defaultChild");
+
+        // Reassign defaultChild on the two internal nodes to point at the LAST
+        // sibling at each level:
+        //   root (id=1): default 2 -> 5  (5 is the second/last child)
+        //   inner (id=2): default 3 -> 4 (4 is the second/last child)
+        tinyxml2::XMLElement * rootNode = model->FirstChildElement("Node");
+        CPPUNIT_ASSERT(rootNode != nullptr);
+        rootNode->SetAttribute("defaultChild", "5");
+        for (tinyxml2::XMLElement * child = rootNode->FirstChildElement("Node"); child; child = child->NextSiblingElement("Node"))
+        {
+            if (const char * idAttr = child->Attribute("id"))
+            {
+                if (std::strcmp(idAttr, "2") == 0)
+                {
+                    child->SetAttribute("defaultChild", "4");
+                }
+            }
+        }
+
+        lua_State * L = makeState(document);
+        CPPUNIT_ASSERT(L != nullptr);
+        std::string strval;
+
+        // outlook missing -> root default is now 5 -> "may play" leaf.
+        // Pre-change, this routes through elseif(outlook==nil or outlook in {overcast,rain}).
+        // Post-change (planned), this routes through plain else.
+        CPPUNIT_ASSERT(executeModel(L, "outlook", nullptr, "temperature", 40.0, "humidity", 70.0));
+        CPPUNIT_ASSERT_EQUAL(true, getValue(L, "id", strval));
+        CPPUNIT_ASSERT_EQUAL(std::string("5"), strval);
+
+        // outlook=sunny: routes into Node 2's subtree. Inside Node 2, both
+        // children are surrogates. Surrogate evaluates the first predicate
+        // and only falls back to the second when the first is *missing*, not
+        // when it's false. So with temperature=40 (non-missing, <50),
+        // pred_3 = FALSE and pred_4 = TRUE -> Node 4. The defaultChild
+        // change doesn't affect this because the predicates resolve cleanly.
+        CPPUNIT_ASSERT(executeModel(L, "outlook", "sunny", "temperature", 40.0, "humidity", 70.0));
+        CPPUNIT_ASSERT_EQUAL(true, getValue(L, "id", strval));
+        CPPUNIT_ASSERT_EQUAL(std::string("4"), strval);
+
+        // outlook=sunny, temperature missing, humidity missing -> both
+        // surrogate predicates have all inputs missing, so they're both
+        // MISSING. With Node 2's defaultChild reassigned to 4, the missing
+        // case routes to Node 4 instead of the original Node 3.
+        CPPUNIT_ASSERT(executeModel(L, "outlook", "sunny", "temperature", nullptr, "humidity", nullptr));
+        CPPUNIT_ASSERT_EQUAL(true, getValue(L, "id", strval));
+        CPPUNIT_ASSERT_EQUAL(std::string("4"), strval);
+
+        // outlook=overcast: explicitly matches Node 5.
+        CPPUNIT_ASSERT(executeModel(L, "outlook", "overcast", "temperature", 40.0, "humidity", 70.0));
+        CPPUNIT_ASSERT_EQUAL(true, getValue(L, "id", strval));
+        CPPUNIT_ASSERT_EQUAL(std::string("5"), strval);
+
+        lua_close(L);
+    }
+
     void testMissingValuePenalty()
     {
         tinyxml2::XMLDocument document;
@@ -235,6 +307,7 @@ public:
     CPPUNIT_TEST_SUITE(TestTree);
     CPPUNIT_TEST(testNoTrueChild);
     CPPUNIT_TEST(testMissingValue);
+    CPPUNIT_TEST(testMissingValueDefaultIsLastSibling);
     CPPUNIT_TEST(testMissingValuePenalty);
     CPPUNIT_TEST(testDefaultValue);
     CPPUNIT_TEST_SUITE_END();


### PR DESCRIPTION
Splits the low-risk, path-attribution-independent work off
`feature/path-attribution-contributions` so it can merge on its own. No
dependency on the `--contributions` feature.

## What's here

- **Regression tests for the SimpleSetPredicate array iterator (MLA-1783 / MLA-2427)**
  Pins the two previously-fixed `PMMLArrayIterator` regressions (leading empty
  string, barewords at end) in `test_predicate.cpp`.

- **Tests for the string→enum converters in pmmldocumentdefs**
  New `test_pmmldocumentdefs.cpp` covering the `<string> → enum` lookup helpers,
  plus its CMake registration.

- **Emit defaultChild's body as `else` when it is the last sibling**
  Tree codegen optimization in `treemodel.cpp`: when
  `missingValueStrategy="defaultChild"`, the default child is the last sibling,
  and no `missingValuePenalty` is set, the default child's body is emitted as
  the trailing `else` of the if-chain instead of a redundant predicated branch.
  Leans on the existing IfChain optimiser pass. Covered by new cases in
  `test_tree.cpp`.

## Correctness / impact

The optimisation only fires when it is provably equivalent (default-as-last,
no penalty); default-as-first and penalty paths are unchanged and regression-
tested. Verified on the validation models:
- CatBoost / XGBoost / LightGBM / random-forest fixtures: byte-identical output.
- LotR uncompact PMML (JPMML `--X-compact false`): fewer `elseif`s / more
  `else`s, numerically identical (max-diff `0.000e+00`). File-size reduction
  ~12–25%.

## Verification

- Builds clean (`libpamplemousse_test`).
- Unit tests: `OK (54)`.