### PR TITLE
Add  --contributions : per-feature path-attribution for tree ensembles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ if (NOT DEFINED skip_tests)
     cuti_creates_test_target(libpamplemousse_test libpamplemousse
         unit_tests/testutils.cpp
         unit_tests/testutils.hpp
+        unit_tests/test_contributions.cpp
         unit_tests/test_function.cpp
         unit_tests/test_miningmodel.cpp
         unit_tests/test_naivebayes.cpp
@@ -102,4 +103,3 @@ else()
   target_compile_options(libpamplemousse PRIVATE -Wshadow -Wall -Wextra -pedantic -Werror)
   target_compile_options(pamplemousse PRIVATE -Wshadow -Wall -Wextra -pedantic -Werror)
 endif()
-

--- a/README.md
+++ b/README.md
@@ -33,6 +33,33 @@ You can see a help message by running pamplemousse without parameters.
 
 Alternatively, if your requirements become more complex, you may use pamplemousse as a library and implement your own input/output logic to the model.
 
+### Per-feature contributions
+
+For tree models and additive ensembles thereof, Pamplemousse can emit
+per-feature path-attribution contributions alongside the score:
+
+```
+pamplemousse --convert --contributions feature_contribs model.pmml > model.lua
+```
+
+For each tree, the generated Lua walks the decision path once and attributes
+the delta `score[child] − score[parent]` to the field tested in the child
+predicate. A separate `__bias__` entry carries `base_score + Σ_trees
+score[root]` so the additive identity `raw_score = __bias__ + Σ contributions`
+holds exactly.
+
+This is the variant produced by XGBoost's own
+`predict(pred_contribs=True, approx_contribs=True)`. It is suitable for
+reason-code / adverse-action use cases where the ranking of features by
+`|contribution|` is what matters; for classifiers with a link function,
+contributions sum to the raw margin (pre-link), not the post-link
+probability, but ranking is preserved across monotonic links.
+
+Supported only for `TreeModel` and for `MiningModel` whose
+`multipleModelMethod` is `sum`, `weightedSum`, `average`, or `modelChain`
+wrapping one of those. Any other model type or ensemble method produces a
+hard error at conversion time when `--contributions` is set.
+
 ## How much of PMML does it support?
 * [Trees](http://dmg.org/pmml/v4-3/TreeModel.html)
 * [Neural Networks](http://dmg.org/pmml/v4-3/NeuralNetwork.html)

--- a/app/basicexport.cpp
+++ b/app/basicexport.cpp
@@ -142,16 +142,70 @@ static void addOutput(AstBuilder & builder, const PMMLExporter::ModelOutput & cu
     }
 }
 
+static void addForPairsLoop(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr table, PMMLDocument::ConstFieldDescriptionPtr key,
+                            PMMLDocument::ConstFieldDescriptionPtr value, AstNode body)
+{
+    builder.field(key);
+    builder.field(value);
+    builder.field(table);
+    builder.pushNode(std::move(body));
+    builder.function(Function::forPairsLoopDef, 4);
+}
+
+static PMMLDocument::ConstFieldDescriptionPtr prepareContributionOutput(AstBuilder & builder, const PMMLExporter::ModelOutput & customOutput)
+{
+    auto result = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "contributions_output", PMMLDocument::ORIGIN_OUTPUT);
+    builder.function(Function::makeTuple, 0);
+    builder.declare(result, AstBuilder::HAS_INITIAL_VALUE);
+
+    auto key = builder.context().createVariable(PMMLDocument::TYPE_STRING, "contribution_key", PMMLDocument::ORIGIN_SPECIAL);
+    auto value = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "contribution_value", PMMLDocument::ORIGIN_SPECIAL);
+    builder.field(value);
+    builder.field(key);
+    builder.assignIndirect(result, 1);
+    AstNode body = builder.popNode();
+    addForPairsLoop(builder, customOutput.field, key, value, std::move(body));
+
+    builder.field(customOutput.biasField);
+    builder.constant("__bias__", PMMLDocument::TYPE_STRING);
+    builder.assignIndirect(result, 1);
+
+    return result;
+}
+
+static void addContributionOutput(AstBuilder & builder, const PMMLExporter::ModelOutput & customOutput)
+{
+    builder.field(prepareContributionOutput(builder, customOutput));
+}
+
 void PMMLExporter::addMultiReturnStatement(AstBuilder & builder, const std::vector<PMMLExporter::ModelOutput> & customOutputs)
 {
-    size_t goodOutputs = std::count_if(customOutputs.begin(), customOutputs.end(), [&builder](const PMMLExporter::ModelOutput & output){
+    std::vector<PMMLDocument::ConstFieldDescriptionPtr> preparedContributionOutputs(customOutputs.size());
+    for (size_t i = 0; i < customOutputs.size(); ++i)
+    {
+        if (customOutputs[i].field && customOutputs[i].isContributions)
+        {
+            preparedContributionOutputs[i] = prepareContributionOutput(builder, customOutputs[i]);
+        }
+    }
+
+    size_t goodOutputs = 0;
+    for (size_t i = 0; i < customOutputs.size(); ++i)
+    {
+        const PMMLExporter::ModelOutput & output = customOutputs[i];
         if (output.field)
         {
-            addOutput(builder, output);
-            return true;
+            if (output.isContributions)
+            {
+                builder.field(preparedContributionOutputs[i]);
+            }
+            else
+            {
+                addOutput(builder, output);
+            }
+            goodOutputs++;
         }
-        return false;
-    });
+    }
     builder.function(ReturnStatement, goodOutputs);
 }
 
@@ -163,7 +217,14 @@ void PMMLExporter::addTableReturnStatement(AstBuilder & builder, const std::vect
     {
         if (output.field)
         {
-            addOutput(builder, output);
+            if (output.isContributions)
+            {
+                addContributionOutput(builder, output);
+            }
+            else
+            {
+                addOutput(builder, output);
+            }
             builder.constant(output.variableOrAttribute, PMMLDocument::TYPE_STRING);
             builder.assignIndirect(var, 1);
         }
@@ -176,7 +237,7 @@ void PMMLExporter::addTableReturnStatement(AstBuilder & builder, const std::vect
 
 bool PMMLExporter::createScript(const char * sourceFile, LuaOutputter & luaOutputter,
                                 std::vector<PMMLExporter::ModelOutput> & inputs, std::vector<PMMLExporter::ModelOutput> & outputs,
-                                Format inputFormat, Format outputFormat)
+                                Format inputFormat, Format outputFormat, const char * contributionsAttribute)
 {
     tinyxml2::XMLDocument doc(sourceFile);
     if (doc.LoadFile(sourceFile) != tinyxml2::XML_SUCCESS)
@@ -186,9 +247,36 @@ bool PMMLExporter::createScript(const char * sourceFile, LuaOutputter & luaOutpu
     }
     
     AstBuilder builder;
-    if (!PMMLDocument::convertPMML( builder, doc.RootElement() ))
+    PMMLDocument::ModelConfig modelConfig;
+    PMMLDocument::ModelConfig * modelConfigPtr = nullptr;
+    PMMLDocument::ConstFieldDescriptionPtr contributionsTable;
+    PMMLDocument::ConstFieldDescriptionPtr biasAccumulator;
+    if (contributionsAttribute)
+    {
+        contributionsTable = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "__contributions__", PMMLDocument::ORIGIN_OUTPUT);
+        biasAccumulator = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "__bias__", PMMLDocument::ORIGIN_OUTPUT);
+        modelConfig.contributionsTable = contributionsTable;
+        modelConfig.biasAccumulator = biasAccumulator;
+        modelConfigPtr = &modelConfig;
+    }
+    if (!PMMLDocument::convertPMML( builder, doc.RootElement(), modelConfigPtr ))
     {
         return false;
+    }
+
+    if (contributionsAttribute)
+    {
+        AstNode model = builder.popNode();
+        builder.function(Function::makeTuple, 0);
+        builder.declare(contributionsTable, AstBuilder::HAS_INITIAL_VALUE);
+        builder.constant(0);
+        builder.declare(biasAccumulator, AstBuilder::HAS_INITIAL_VALUE);
+        builder.pushNode(std::move(model));
+        builder.block(3);
+
+        outputs.emplace_back("__contributions__", contributionsAttribute, contributionsTable);
+        outputs.back().biasField = biasAccumulator;
+        outputs.back().isContributions = true;
     }
 
     populateIOWithDictionary(inputs, builder.context().getInputs());
@@ -221,6 +309,10 @@ bool PMMLExporter::createScript(const char * sourceFile, LuaOutputter & luaOutpu
 
     size_t countBound = std::count_if(outputs.begin(), outputs.end(), [&builder](PMMLExporter::ModelOutput & output)
     {
+        if (output.isContributions && output.field)
+        {
+            return true;
+        }
         if (output.bindToModel(builder.context()))
             return true;
         std::cerr << "Output \"" <<  output.modelOutput << "\" was not found in the model." << std::endl;

--- a/app/basicexport.hpp
+++ b/app/basicexport.hpp
@@ -33,7 +33,8 @@ namespace PMMLExporter
     // inputs and outputs are both io parameters. If they are non-empty, they will be used. If they are empty, we will populate them from the model.
     bool createScript(const char * sourceFile, LuaOutputter & luaOutputter,
                       std::vector<PMMLExporter::ModelOutput> & inputs, std::vector<PMMLExporter::ModelOutput> & outputs,
-                      Format inputFormat = Format::AS_MULTI_ARG, Format outputFormat = Format::AS_MULTI_ARG);
+                      Format inputFormat = Format::AS_MULTI_ARG, Format outputFormat = Format::AS_MULTI_ARG,
+                      const char * contributionsAttribute = nullptr);
     void addFunctionHeader(LuaOutputter & output, const std::vector<PMMLExporter::ModelOutput> & inputColumns);
     void addMultiReturnStatement(AstBuilder & builder, const std::vector<PMMLExporter::ModelOutput> & customOutputs);
     void addTableReturnStatement(AstBuilder & builder, const std::vector<PMMLExporter::ModelOutput> & customOutputs);

--- a/app/modeloutput.hpp
+++ b/app/modeloutput.hpp
@@ -28,9 +28,11 @@ namespace PMMLExporter
         std::string modelOutput;
         std::string variableOrAttribute;
         PMMLDocument::ConstFieldDescriptionPtr field;
+        PMMLDocument::ConstFieldDescriptionPtr biasField;
         double factor = 1;
         double coefficient = 0;
         int decimalPoints = -1;
+        bool isContributions = false;
         
         ModelOutput(const std::string & mo, const std::string & voa,
                     PMMLDocument::ConstFieldDescriptionPtr field = PMMLDocument::ConstFieldDescriptionPtr());

--- a/app/pamplemousse.cpp
+++ b/app/pamplemousse.cpp
@@ -105,6 +105,7 @@ static void printUsage(const char * programName, option* longopts)
         "Use table for inputs",
         "Use multiple parameters for outputs",
         "Use table for outputs",
+        "Output per-feature contributions to a custom attribute.",
         nullptr
     };
     
@@ -180,16 +181,18 @@ int main(int argc, char *argv[])
         { "input_table",no_argument,     &inputFormat, int(PMMLExporter::Format::AS_TABLE) },
         { "output_multi",no_argument,    &outputFormat,int(PMMLExporter::Format::AS_MULTI_ARG) },
         { "output_table",no_argument,    &outputFormat,int(PMMLExporter::Format::AS_TABLE) },
+        { "contributions",required_argument,NULL,       'x' },
         { NULL,        0,                NULL,          0 }
     };
     
-    static constexpr char OPTSTRING[] = "id:v:o:f:p:he:TC";
+    static constexpr char OPTSTRING[] = "id:v:o:f:p:he:x:TC";
 
     const char * dataFile   = nullptr;
     const char * verifyFile = nullptr;
     const char * outputFile = nullptr;
     bool insensitive = false;
     double epsilon = 0.0001;
+    const char * contributionsAttribute = nullptr;
     std::vector<PMMLExporter::ModelOutput> inputs;
     std::vector<PMMLExporter::ModelOutput> outputs;
     int8_t c;
@@ -240,6 +243,10 @@ int main(int argc, char *argv[])
             {
                 outputs.emplace_back(customOutput, customOutput);
             }
+        }
+        else if (c == 'x')
+        {
+            contributionsAttribute = optarg;
         }
         else if (c == 'h')
         {
@@ -313,7 +320,7 @@ int main(int argc, char *argv[])
     {
         LuaOutputter output(outputFile ? outFileStream : std::cout, insensitive ? LuaOutputter::OPTION_LOWERCASE : 0);
 
-        if (!PMMLExporter::createScript(sourceFile, output, inputs, outputs, PMMLExporter::Format(inputFormat), PMMLExporter::Format(outputFormat)))
+        if (!PMMLExporter::createScript(sourceFile, output, inputs, outputs, PMMLExporter::Format(inputFormat), PMMLExporter::Format(outputFormat), contributionsAttribute))
         {
             return -1;
         }

--- a/common/document.cpp
+++ b/common/document.cpp
@@ -115,7 +115,7 @@ void findAllInputs(const tinyxml2::XMLElement * element, std::unordered_set<std:
 }
 }
 
-bool PMMLDocument::convertPMML(AstBuilder & builder, const tinyxml2::XMLElement * documentRoot)
+bool PMMLDocument::convertPMML(AstBuilder & builder, const tinyxml2::XMLElement * documentRoot, const ModelConfig * initialConfig)
 {
     const tinyxml2::XMLElement * header = documentRoot->FirstChildElement();
     if (header == nullptr)
@@ -191,6 +191,10 @@ bool PMMLDocument::convertPMML(AstBuilder & builder, const tinyxml2::XMLElement 
     }
     
     ModelConfig config;
+    if (initialConfig)
+    {
+        config = *initialConfig;
+    }
     {
         // This thing is only used to get the target / predicted value from the mining schema.
         MiningSchemaStackGuard miningSchema(builder.context(), model->FirstChildElement("MiningSchema"));

--- a/common/document.hpp
+++ b/common/document.hpp
@@ -56,6 +56,8 @@ namespace PMMLDocument
         ConstFieldDescriptionPtr reasonCodeValueName;
         // This variable is where the best probability should be written to.
         ConstFieldDescriptionPtr bestProbabilityValueName;
+        ConstFieldDescriptionPtr contributionsTable;
+        ConstFieldDescriptionPtr biasAccumulator;
         // This represents the type of output this model is exprected to deliver, or TYPE_INVALID if it doesn't matter.
         PMMLDocument::FieldType outputType;
         ConstFieldDescriptionPtr targetField;
@@ -95,7 +97,7 @@ namespace PMMLDocument
     
     
     // This is a high level function that takes a root node of a PMML document and emits Lua source code.
-    bool convertPMML(AstBuilder & builder, const tinyxml2::XMLElement * documentRoot);
+    bool convertPMML(AstBuilder & builder, const tinyxml2::XMLElement * documentRoot, const ModelConfig * initialConfig = nullptr);
 }
 
 #endif /* document_hpp */

--- a/common/function.cpp
+++ b/common/function.cpp
@@ -141,6 +141,7 @@ const FunctionTable functionTable = {{
     const Definition sortTableDef = {"table.sort", FUNCTIONLIKE, PMMLDocument::TYPE_VOID, LuaOutputter::PRECEDENCE_TOP, MISSING_IF_ANY_ARGUMENT_IS_MISSING };
     const Definition insertToTableDef = {"table.insert", FUNCTIONLIKE, PMMLDocument::TYPE_VOID,LuaOutputter::PRECEDENCE_TOP, MISSING_IF_ANY_ARGUMENT_IS_MISSING};
     const Definition listLengthDef = {"#", UNARY_OPERATOR, PMMLDocument::TYPE_NUMBER, LuaOutputter::PRECEDENCE_UNARY, MISSING_IF_ANY_ARGUMENT_IS_MISSING};
+    const Definition forPairsLoopDef = {nullptr, FOR_PAIRS_LOOP, PMMLDocument::TYPE_VOID, LuaOutputter::PRECEDENCE_TOP, NEVER_MISSING};
 
     // These are for predicate
     // Surrogate's lua function is defined as an "or" to allow it to be expressed as A or B or C... iff the type is not bool

--- a/common/function.hpp
+++ b/common/function.hpp
@@ -72,6 +72,7 @@ namespace Function
         LAMBDA,
         RUN_LAMBDA,
         RETURN_STATEMENT,
+        FOR_PAIRS_LOOP,
         UNSUPPORTED
     };
     enum MissingValueRule
@@ -208,6 +209,7 @@ namespace Function
     extern const Definition sortTableDef;
     extern const Definition insertToTableDef;
     extern const Definition listLengthDef;
+    extern const Definition forPairsLoopDef;
     
     struct CustomDefinition
     {

--- a/common/functiondispatch.hpp
+++ b/common/functiondispatch.hpp
@@ -56,6 +56,7 @@ namespace Function
     class Lambda : public FunctionTypeBase{};
     class RunLambda : public FunctionTypeBase{};
     class ReturnStatement : public FunctionTypeBase{};
+    class ForPairsLoop : public FunctionTypeBase{};
     
     
     template<typename ReturnType, class Dispatcher, typename... Ts>
@@ -155,7 +156,10 @@ namespace Function
                 
             case RETURN_STATEMENT:
                 return dispatcher.process(ReturnStatement(), args...);
-                
+
+            case FOR_PAIRS_LOOP:
+                return dispatcher.process(ForPairsLoop(), args...);
+                 
             case UNSUPPORTED:
                 break;
         }

--- a/luaconverter/luaconverter-internal.hpp
+++ b/luaconverter/luaconverter-internal.hpp
@@ -53,6 +53,7 @@ namespace LuaConverter
         static void process(Function::Lambda, Analyser::AnalyserContext & context, const AstNode & node, DefaultIfMissing defaultIfMissing, LuaOutputter & output);
         static void process(Function::RunLambda, Analyser::AnalyserContext & context, const AstNode & node, DefaultIfMissing defaultIfMissing, LuaOutputter & output);
         static void process(Function::ReturnStatement, Analyser::AnalyserContext & context, const AstNode & node, DefaultIfMissing defaultIfMissing, LuaOutputter & output);
+        static void process(Function::ForPairsLoop, Analyser::AnalyserContext & context, const AstNode & node, DefaultIfMissing defaultIfMissing, LuaOutputter & output);
     };
     
     class MissingClauseConverter

--- a/luaconverter/luaconverter-procedural.cpp
+++ b/luaconverter/luaconverter-procedural.cpp
@@ -115,9 +115,28 @@ void LuaConverter::Converter::process(Function::IfChain, Analyser::AnalyserConte
             continuingNonNullAssertions.addAssertionsForCheck(*predicate, Analyser::ASSUME_NOT_TRUE);
         }
     }
-    
     if (hasStartedBlock)
     {
         output.endBlock();
     }
+}
+
+void LuaConverter::Converter::process(Function::ForPairsLoop, Analyser::AnalyserContext & context, const AstNode & node, DefaultIfMissing, LuaOutputter & output)
+{
+    assert(node.children.size() == 4);
+    assert(node.children[0].function().functionType == Function::FIELD_REF);
+    assert(node.children[1].function().functionType == Function::FIELD_REF);
+
+    output.startFor();
+    output.rawField(node.children[0].fieldDescription);
+    output.comma();
+    output.rawField(node.children[1].fieldDescription);
+    output.keyword("in pairs");
+    output.openParen();
+    convertAstToLuaWithNullAssertions(context, node.children[2], DEFAULT_TO_NIL, output);
+    output.closeParen();
+    output.endPredicate();
+    convertAstSkipNullChecks(context, node.children[3], DEFAULT_TO_NIL, output);
+    output.endline();
+    output.endBlock();
 }

--- a/luaconverter/luaoutputter.cpp
+++ b/luaconverter/luaoutputter.cpp
@@ -78,6 +78,15 @@ LuaOutputter & LuaOutputter::startWhile()
     return *this;
 }
 
+LuaOutputter & LuaOutputter::startFor()
+{
+    assert(isBlock(getContext()));
+    keyword("for");
+    m_indentLevel++;
+    m_stack.push_back(WHILE_PREDICATE);
+    return *this;
+}
+
 LuaOutputter & LuaOutputter::function()
 {
     keyword("function(");
@@ -437,4 +446,3 @@ LuaOutputter & LuaOutputter::closeBracket()
     m_spaceState = AFTER_KEYWORD;
     return *this;
 }
-

--- a/luaconverter/luaoutputter.hpp
+++ b/luaconverter/luaoutputter.hpp
@@ -157,6 +157,7 @@ public:
     LuaOutputter & startElseIf();
     LuaOutputter & startElse();
     LuaOutputter & startWhile();
+    LuaOutputter & startFor();
     LuaOutputter & function();
     LuaOutputter & function(const char * functionName);
     LuaOutputter & finishedArguments();

--- a/luaconverter/optimiser.cpp
+++ b/luaconverter/optimiser.cpp
@@ -118,6 +118,15 @@ public:
             traverseNode<maintainAssertions>(ctx, node.children.back(), counter, visitor, &innerAssertions);
         }
     }
+
+    static void process(Function::ForPairsLoop, Analyser::AnalyserContext & ctx, AstNode & node, size_t & counter, ASTVisitor & visitor, Analyser::NonNoneAssertionStackGuard * parentAssertions)
+    {
+        if (node.children.size() == 4)
+        {
+            traverseNode<maintainAssertions>(ctx, node.children[2], counter, visitor, nullptr);
+            traverseNode<maintainAssertions>(ctx, node.children[3], counter, visitor, parentAssertions);
+        }
+    }
     
     static void process(Function::Block, Analyser::AnalyserContext & ctx, AstNode & node, size_t & counter, ASTVisitor & visitor, Analyser::NonNoneAssertionStackGuard * parentAssertions)
     {

--- a/luaconverter/optimiser.cpp
+++ b/luaconverter/optimiser.cpp
@@ -119,12 +119,18 @@ public:
         }
     }
 
-    static void process(Function::ForPairsLoop, Analyser::AnalyserContext & ctx, AstNode & node, size_t & counter, ASTVisitor & visitor, Analyser::NonNoneAssertionStackGuard * parentAssertions)
+    static void process(Function::ForPairsLoop, Analyser::AnalyserContext & ctx, AstNode & node, size_t & counter, ASTVisitor & visitor, Analyser::NonNoneAssertionStackGuard * /*parentAssertions*/)
     {
         if (node.children.size() == 4)
         {
             traverseNode<maintainAssertions>(ctx, node.children[2], counter, visitor, nullptr);
-            traverseNode<maintainAssertions>(ctx, node.children[3], counter, visitor, parentAssertions);
+            // The body of `for k,v in pairs(t) do ... end` runs zero or more
+            // times depending on the table's contents, so any non-none
+            // assertion the body establishes must NOT propagate to the
+            // surrounding scope (the body might never run). Mirrors what
+            // `process(Function::Lambda, ...)` above does for the same reason.
+            Analyser::NonNoneAssertionStackGuard innerAssertions(ctx);
+            traverseNode<maintainAssertions>(ctx, node.children[3], counter, visitor, &innerAssertions);
         }
     }
     

--- a/model/generalregressionmodel.cpp
+++ b/model/generalregressionmodel.cpp
@@ -252,6 +252,11 @@ buildPPMatrix(AstBuilder & builder, ParametersVector & parameters, std::map<std:
 
 bool GeneralRegressionModel::parse(AstBuilder & builder, const tinyxml2::XMLElement * node, PMMLDocument::ModelConfig & config)
 {
+    if (config.contributionsTable)
+    {
+        builder.parsingError("--contributions is only supported on tree models and additive ensembles thereof", node->GetLineNum());
+        return false;
+    }
     ParametersVector parameters;
     if (const tinyxml2::XMLElement * parameterList = node->FirstChildElement("ParameterList"))
     {

--- a/model/miningmodel.cpp
+++ b/model/miningmodel.cpp
@@ -505,18 +505,18 @@ namespace MiningModel
             size_t innerBlockSize = 1;
             if (config.contributionsTable)
             {
-                // ORIGIN_SPECIAL (not ORIGIN_OUTPUT) so the optimiser does not
-                // alias these submodel-scratch locals onto an input feature
-                // variable; if it did, the merge-into-parent loop below would
-                // read/write the feature and corrupt downstream tree evals.
-                subModelConfig.contributionsTable = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "model_contributions", PMMLDocument::ORIGIN_SPECIAL);
+                // Default origin (ORIGIN_TEMPORARY) so the optimiser can spill
+                // these per-segment scratch locals into the overflow array
+                // when the ensemble has too many trees to fit in Lua's
+                // 200-locals-per-function budget.
+                subModelConfig.contributionsTable = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "model_contributions");
                 builder.function(Function::makeTuple, 0);
                 builder.declare(subModelConfig.contributionsTable, AstBuilder::HAS_INITIAL_VALUE);
                 innerBlockSize++;
             }
             if (config.biasAccumulator)
             {
-                subModelConfig.biasAccumulator = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "model_bias", PMMLDocument::ORIGIN_SPECIAL);
+                subModelConfig.biasAccumulator = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "model_bias");
                 builder.constant(0);
                 builder.declare(subModelConfig.biasAccumulator, AstBuilder::HAS_INITIAL_VALUE);
                 innerBlockSize++;

--- a/model/miningmodel.cpp
+++ b/model/miningmodel.cpp
@@ -68,6 +68,11 @@ namespace MiningModel
             }
         }
     }
+
+    size_t mergeContributionsFromSubModel(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr contributionsTable,
+                                          PMMLDocument::ConstFieldDescriptionPtr subContributionsTable, const char * weight);
+    size_t addBiasFromSubModel(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr biasAccumulator,
+                               PMMLDocument::ConstFieldDescriptionPtr subBiasAccumulator, const char * weight);
     
     
     size_t copyResultsFromSubModel(AstBuilder & builder, const PMMLDocument::ModelConfig & config, const PMMLDocument::ModelConfig & subModelConfig)
@@ -113,6 +118,16 @@ namespace MiningModel
                 blockSize++;
             }
         }
+
+        if (config.contributionsTable && subModelConfig.contributionsTable)
+        {
+            blockSize += mergeContributionsFromSubModel(builder, config.contributionsTable, subModelConfig.contributionsTable, nullptr);
+        }
+
+        if (config.biasAccumulator && subModelConfig.biasAccumulator)
+        {
+            blockSize += addBiasFromSubModel(builder, config.biasAccumulator, subModelConfig.biasAccumulator, nullptr);
+        }
         
         return blockSize;
     }
@@ -146,6 +161,90 @@ namespace MiningModel
             blockSize++;
         }
         return blockSize;
+    }
+
+    void addForPairsLoop(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr table, PMMLDocument::ConstFieldDescriptionPtr key,
+                         PMMLDocument::ConstFieldDescriptionPtr value, AstNode body)
+    {
+        builder.field(key);
+        builder.field(value);
+        builder.field(table);
+        builder.pushNode(std::move(body));
+        builder.function(Function::forPairsLoopDef, 4);
+    }
+
+    size_t mergeContributionsFromSubModel(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr contributionsTable,
+                                          PMMLDocument::ConstFieldDescriptionPtr subContributionsTable, const char * weight)
+    {
+        auto key = builder.context().createVariable(PMMLDocument::TYPE_STRING, "contribution_key", PMMLDocument::ORIGIN_SPECIAL);
+        auto value = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "contribution_value", PMMLDocument::ORIGIN_SPECIAL);
+
+        builder.field(key);
+        builder.fieldIndirect(contributionsTable, 1);
+        builder.defaultValue("0");
+        builder.field(value);
+        if (weight)
+        {
+            builder.constant(weight, PMMLDocument::TYPE_NUMBER);
+            builder.function(Function::functionTable.names.times, 2);
+        }
+        builder.function(Function::functionTable.names.plus, 2);
+        builder.field(key);
+        builder.assignIndirect(contributionsTable, 1);
+
+        AstNode body = builder.popNode();
+        addForPairsLoop(builder, subContributionsTable, key, value, std::move(body));
+        return 1;
+    }
+
+    size_t divideContributions(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr contributionsTable,
+                               PMMLDocument::ConstFieldDescriptionPtr factor)
+    {
+        auto key = builder.context().createVariable(PMMLDocument::TYPE_STRING, "contribution_key", PMMLDocument::ORIGIN_SPECIAL);
+        auto value = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "contribution_value", PMMLDocument::ORIGIN_SPECIAL);
+
+        builder.field(value);
+        builder.field(factor);
+        builder.function(Function::functionTable.names.divide, 2);
+        builder.field(key);
+        builder.assignIndirect(contributionsTable, 1);
+
+        AstNode body = builder.popNode();
+        addForPairsLoop(builder, contributionsTable, key, value, std::move(body));
+        return 1;
+    }
+
+    size_t addBiasFromSubModel(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr biasAccumulator,
+                               PMMLDocument::ConstFieldDescriptionPtr subBiasAccumulator, const char * weight)
+    {
+        builder.field(biasAccumulator);
+        builder.defaultValue("0");
+        builder.field(subBiasAccumulator);
+        builder.defaultValue("0");
+        if (weight)
+        {
+            builder.constant(weight, PMMLDocument::TYPE_NUMBER);
+            builder.function(Function::functionTable.names.times, 2);
+        }
+        builder.function(Function::functionTable.names.plus, 2);
+        builder.assign(biasAccumulator);
+        return 1;
+    }
+
+    const char * unsupportedContributionsMethod(MultipleModelMethod modelMethod)
+    {
+        switch(modelMethod)
+        {
+            case MAJORITYVOTE:
+            case WEIGHTEDMAJORITYVOTE:
+            case MAX:
+            case MEDIAN:
+            case SELECTFIRST:
+            case SELECTALL:
+                return MUTLIPLE_MODEL_METHOD_NAME[modelMethod];
+            default:
+                return nullptr;
+        }
     }
     
     size_t setupAccumulatorsForProbabilities(AstBuilder & builder, PMMLDocument::ModelConfig & config, const MultipleModelMethod modelMethod)
@@ -301,6 +400,8 @@ namespace MiningModel
             {
                 PMMLDocument::ModelConfig subModuleConfig;
                 // This model is used purely for chaining.
+                subModuleConfig.contributionsTable = config.contributionsTable;
+                subModuleConfig.biasAccumulator = config.biasAccumulator;
                 if (!PMMLDocument::parseModel(builder, model, subModuleConfig))
                 {
                     return false;
@@ -309,7 +410,17 @@ namespace MiningModel
             else
             {
                 // The child model outputs in the same way as the parent.
-                if (!PMMLDocument::parseModel(builder, model, config))
+                auto contributionsTable = config.contributionsTable;
+                auto biasAccumulator = config.biasAccumulator;
+                if (modelMethod == MODELCHAIN)
+                {
+                    config.contributionsTable = nullptr;
+                    config.biasAccumulator = nullptr;
+                }
+                const bool parsed = PMMLDocument::parseModel(builder, model, config);
+                config.contributionsTable = contributionsTable;
+                config.biasAccumulator = biasAccumulator;
+                if (!parsed)
                 {
                     return false;
                 }
@@ -360,7 +471,7 @@ namespace MiningModel
     }
 
     // This handles all other multiple model methods for regression models.
-    bool doRegressionSegments(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr outputValueName, PMMLDocument::FieldType outputType,
+    bool doRegressionSegments(AstBuilder & builder, PMMLDocument::ModelConfig & config, PMMLDocument::ConstFieldDescriptionPtr outputValueName, PMMLDocument::FieldType outputType,
                               PMMLDocument::ConstFieldDescriptionPtr countName, const tinyxml2::XMLElement * segmentation, const MultipleModelMethod modelMethod,
                               double & constCount)
     {
@@ -391,12 +502,30 @@ namespace MiningModel
             subModelConfig.outputValueName = builder.context().createVariable(outputType, "model_output");
             subModelConfig.outputType = outputType;
             subModelConfig.function = PMMLDocument::FUNCTION_REGRESSION;
+            size_t innerBlockSize = 1;
+            if (config.contributionsTable)
+            {
+                // ORIGIN_SPECIAL (not ORIGIN_OUTPUT) so the optimiser does not
+                // alias these submodel-scratch locals onto an input feature
+                // variable; if it did, the merge-into-parent loop below would
+                // read/write the feature and corrupt downstream tree evals.
+                subModelConfig.contributionsTable = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "model_contributions", PMMLDocument::ORIGIN_SPECIAL);
+                builder.function(Function::makeTuple, 0);
+                builder.declare(subModelConfig.contributionsTable, AstBuilder::HAS_INITIAL_VALUE);
+                innerBlockSize++;
+            }
+            if (config.biasAccumulator)
+            {
+                subModelConfig.biasAccumulator = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "model_bias", PMMLDocument::ORIGIN_SPECIAL);
+                builder.constant(0);
+                builder.declare(subModelConfig.biasAccumulator, AstBuilder::HAS_INITIAL_VALUE);
+                innerBlockSize++;
+            }
             if (!PMMLDocument::parseModel(builder, model, subModelConfig))
             {
                 return false;
             }
-            size_t innerBlockSize = 1;
-            
+             
             if (modelMethod == SUM ||
                 modelMethod == WEIGHTEDAVERAGE ||
                 modelMethod == AVERAGE)
@@ -415,6 +544,18 @@ namespace MiningModel
                 builder.function(Function::functionTable.names.plus, 2);
                 builder.assign(outputValueName);
                 innerBlockSize++;
+
+                if (config.contributionsTable && subModelConfig.contributionsTable)
+                {
+                    innerBlockSize += mergeContributionsFromSubModel(builder, config.contributionsTable, subModelConfig.contributionsTable,
+                                                                     modelMethod == WEIGHTEDAVERAGE ? weight : nullptr);
+                }
+
+                if (config.biasAccumulator && subModelConfig.biasAccumulator)
+                {
+                    innerBlockSize += addBiasFromSubModel(builder, config.biasAccumulator, subModelConfig.biasAccumulator,
+                                                          modelMethod == WEIGHTEDAVERAGE ? weight : nullptr);
+                }
             }
             else if (modelMethod == MEDIAN)
             {
@@ -690,6 +831,14 @@ namespace MiningModel
                          const char * method, const tinyxml2::XMLElement * segmentation)
     {
         const MultipleModelMethod modelMethod = getMiningModelFromString(method);
+        if (config.contributionsTable)
+        {
+            if (const char * unsupported = unsupportedContributionsMethod(modelMethod))
+            {
+                builder.parsingError("multipleModelMethod is not supported with --contributions", unsupported, node->GetLineNum());
+                return false;
+            }
+        }
         switch(modelMethod)
         {
             case INVALID:
@@ -710,12 +859,11 @@ namespace MiningModel
                 builder.declare(countVariable, AstBuilder::HAS_INITIAL_VALUE);
             
                 double constCount = 0;
-                if (!doRegressionSegments(builder, accumVariable, config.outputType, countVariable, segmentation, modelMethod, constCount))
+                if (!doRegressionSegments(builder, config, accumVariable, config.outputType, countVariable, segmentation, modelMethod, constCount))
                 {
                     return false;
                 }
                 
-                builder.field(accumVariable);
                 builder.field(countVariable);
                 // Add a constant count to the calculated count
                 if (constCount > 0)
@@ -723,10 +871,29 @@ namespace MiningModel
                     builder.constant(constCount);
                     builder.function(Function::functionTable.names.sum, 2);
                 }
+                auto totalCountVariable = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "total_count");
+                builder.declare(totalCountVariable, AstBuilder::HAS_INITIAL_VALUE);
+
+                builder.field(accumVariable);
+                builder.field(totalCountVariable);
                 builder.function(Function::functionTable.names.divide, 2);
                 builder.declare(config.outputValueName, AstBuilder::HAS_INITIAL_VALUE);
-                
-                builder.block(4);
+
+                size_t blockSize = 5;
+                if (config.contributionsTable)
+                {
+                    blockSize += divideContributions(builder, config.contributionsTable, totalCountVariable);
+                }
+                if (config.biasAccumulator)
+                {
+                    builder.field(config.biasAccumulator);
+                    builder.field(totalCountVariable);
+                    builder.function(Function::functionTable.names.divide, 2);
+                    builder.assign(config.biasAccumulator);
+                    blockSize++;
+                }
+
+                builder.block(blockSize);
                 return true;
             }
             case MEDIAN:
@@ -736,7 +903,7 @@ namespace MiningModel
                 builder.declare(accumVariable, AstBuilder::NO_INITIAL_VALUE);
                 
                 double constCount = 0;
-                if (!doRegressionSegments(builder, accumVariable, config.outputType, nullptr, segmentation, modelMethod, constCount))
+                if (!doRegressionSegments(builder, config, accumVariable, config.outputType, nullptr, segmentation, modelMethod, constCount))
                 {
                     return false;
                 }
@@ -779,7 +946,7 @@ namespace MiningModel
                 builder.constant(0);
                 builder.declare(config.outputValueName, AstBuilder::HAS_INITIAL_VALUE);
                 double constCount = 0;
-                if (!doRegressionSegments(builder, config.outputValueName, config.outputType, nullptr, segmentation, modelMethod, constCount))
+                if (!doRegressionSegments(builder, config, config.outputValueName, config.outputType, nullptr, segmentation, modelMethod, constCount))
                 {
                     return false;
                 }
@@ -801,6 +968,14 @@ namespace MiningModel
                              const char * method, const tinyxml2::XMLElement * segmentation)
     {
         const MultipleModelMethod modelMethod = getMiningModelFromString(method);
+        if (config.contributionsTable)
+        {
+            if (const char * unsupported = unsupportedContributionsMethod(modelMethod))
+            {
+                builder.parsingError("multipleModelMethod is not supported with --contributions", unsupported, node->GetLineNum());
+                return false;
+            }
+        }
         switch(modelMethod)
         {
             case INVALID:

--- a/model/miningmodel.cpp
+++ b/model/miningmodel.cpp
@@ -1031,3 +1031,49 @@ bool MiningModel::parse(AstBuilder & builder, const tinyxml2::XMLElement * node,
     builder.parsingError("No segmentation element in MiningModel", node->GetLineNum());
     return false;
 }
+
+size_t MiningModel::applyRescaleToContributions(AstBuilder & builder,
+                                                const PMMLDocument::ModelConfig & config,
+                                                bool hasFactor, double factor,
+                                                bool hasConstant, double constant)
+{
+    size_t emitted = 0;
+    const bool factorActive = hasFactor && factor != 1.0;
+
+    if (config.contributionsTable && factorActive)
+    {
+        // for k,v in pairs(contributionsTable) do contributionsTable[k] = v * factor end
+        auto key = builder.context().createVariable(PMMLDocument::TYPE_STRING, "contribution_key", PMMLDocument::ORIGIN_SPECIAL);
+        auto value = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "contribution_value", PMMLDocument::ORIGIN_SPECIAL);
+
+        builder.field(value);
+        builder.constant(factor);
+        builder.function(Function::functionTable.names.times, 2);
+        builder.field(key);
+        builder.assignIndirect(config.contributionsTable, 1);
+
+        AstNode body = builder.popNode();
+        addForPairsLoop(builder, config.contributionsTable, key, value, std::move(body));
+        emitted++;
+    }
+
+    if (config.biasAccumulator && (factorActive || (hasConstant && constant != 0.0)))
+    {
+        // bias = bias * factor + constant
+        builder.field(config.biasAccumulator);
+        if (factorActive)
+        {
+            builder.constant(factor);
+            builder.function(Function::functionTable.names.times, 2);
+        }
+        if (hasConstant && constant != 0.0)
+        {
+            builder.constant(constant);
+            builder.function(Function::functionTable.names.plus, 2);
+        }
+        builder.assign(config.biasAccumulator);
+        emitted++;
+    }
+
+    return emitted;
+}

--- a/model/miningmodel.hpp
+++ b/model/miningmodel.hpp
@@ -24,6 +24,24 @@
 namespace MiningModel
 {
     bool parse(AstBuilder & builder, const tinyxml2::XMLElement * node, PMMLDocument::ModelConfig & config);
+
+    // Apply the same linear transform (x -> x*factor + constant) that
+    // <Target rescaleFactor="..." rescaleConstant="..."/> applies to the
+    // model's score output, so the Saabas invariant
+    //     bias + sum(per-feature contributions) == model_score
+    // continues to hold for the contribution bundle.
+    //
+    // - The bias accumulator (if set) is updated in place.
+    // - Each entry of the contributions table (if set) is multiplied by
+    //   factor when factor != 1.0; rescaleConstant only affects the bias.
+    // No-op (and emits nothing) if neither factor nor constant is set or
+    // the model has no biasAccumulator/contributionsTable to update.
+    //
+    // Returns the number of statements emitted (added to blockSize by caller).
+    size_t applyRescaleToContributions(AstBuilder & builder,
+                                       const PMMLDocument::ModelConfig & config,
+                                       bool hasFactor, double factor,
+                                       bool hasConstant, double constant);
 }
 
 #endif /* miningmodel_hpp */

--- a/model/naivebayesmodel.cpp
+++ b/model/naivebayesmodel.cpp
@@ -292,6 +292,11 @@ static bool loadInputMappings(AstBuilder & builder, const tinyxml2::XMLElement *
 
 bool NaiveBayesModel::parse(AstBuilder & builder, const tinyxml2::XMLElement * node, PMMLDocument::ModelConfig & config)
 {
+    if (config.contributionsTable)
+    {
+        builder.parsingError("--contributions is only supported on tree models and additive ensembles thereof", node->GetLineNum());
+        return false;
+    }
     const tinyxml2::XMLElement * inputs = node->FirstChildElement("BayesInputs");
     if (inputs == nullptr)
     {

--- a/model/neuralnetworkmodel.cpp
+++ b/model/neuralnetworkmodel.cpp
@@ -585,6 +585,11 @@ namespace
 
 bool NeuralNetworkModel::parse(AstBuilder & builder, const tinyxml2::XMLElement * node, PMMLDocument::ModelConfig & config)
 {
+    if (config.contributionsTable)
+    {
+        builder.parsingError("--contributions is only supported on tree models and additive ensembles thereof", node->GetLineNum());
+        return false;
+    }
     const char * activationFunctionName = node->Attribute("activationFunction");
     if (activationFunctionName == nullptr)
     {

--- a/model/output.cpp
+++ b/model/output.cpp
@@ -21,6 +21,7 @@
 #include "conversioncontext.hpp"
 #include "document.hpp"
 #include "transformation.hpp"
+#include "miningmodel.hpp"
 #include <algorithm>
 
 namespace
@@ -134,6 +135,10 @@ void Output::doTargetPostprocessing(AstBuilder & builder, const tinyxml2::XMLEle
             }
             
             double val;
+            double rescaleFactor = 1.0;
+            double rescaleConstant = 0.0;
+            bool hasRescaleFactor = false;
+            bool hasRescaleConstant = false;
             if (target->QueryAttribute("max", &val) == tinyxml2::XML_SUCCESS)
             {
                 builder.constant(val);
@@ -151,12 +156,16 @@ void Output::doTargetPostprocessing(AstBuilder & builder, const tinyxml2::XMLEle
                 builder.constant(val);
                 builder.function(Function::functionTable.names.times, 2);
                 doneAnythingUseful = true;
+                rescaleFactor = val;
+                hasRescaleFactor = true;
             }
             if (target->QueryAttribute("rescaleConstant", &val) == tinyxml2::XML_SUCCESS)
             {
                 builder.constant(val);
                 builder.function(Function::functionTable.names.plus, 2);
                 doneAnythingUseful = true;
+                rescaleConstant = val;
+                hasRescaleConstant = true;
             }
             
             if (const char * castInteger = target->Attribute("castInteger"))
@@ -186,6 +195,16 @@ void Output::doTargetPostprocessing(AstBuilder & builder, const tinyxml2::XMLEle
                 // Get rid of the field ref.
                 builder.popNode();
             }
+
+            // Mirror the linear part of the score's rescale onto the
+            // contribution bias accumulator (and contribution table if
+            // factor != 1) so that bias + sum(contribs) tracks the rescaled
+            // score. Nonlinear ops (min/max/castInteger) intentionally do
+            // not propagate to contributions.
+            blockSize += MiningModel::applyRescaleToContributions(
+                builder, modelConfig,
+                hasRescaleFactor, rescaleFactor,
+                hasRescaleConstant, rescaleConstant);
         }
     }
 }

--- a/model/regressionmodel.cpp
+++ b/model/regressionmodel.cpp
@@ -393,6 +393,11 @@ bool RegressionModel::buildCatagoricalPredictor(AstBuilder & builder, const tiny
 
 bool RegressionModel::parse(AstBuilder & builder, const tinyxml2::XMLElement * node, PMMLDocument::ModelConfig & config)
 {
+    if (config.contributionsTable)
+    {
+        builder.parsingError("--contributions is only supported on tree models and additive ensembles thereof", node->GetLineNum());
+        return false;
+    }
     RegressionNormalizationMethod normMethod = METHOD_NONE;
     if (const char * methodName = node->Attribute("normalizationMethod"))
     {

--- a/model/rulesetmodel.cpp
+++ b/model/rulesetmodel.cpp
@@ -87,6 +87,11 @@ bool parseScope(std::vector<Rule> & rules, AstBuilder & builder, const tinyxml2:
 
 bool RulesetModel::parse(AstBuilder & builder, const tinyxml2::XMLElement * node, PMMLDocument::ModelConfig & config)
 {
+    if (config.contributionsTable)
+    {
+        builder.parsingError("--contributions is only supported on tree models and additive ensembles thereof", node->GetLineNum());
+        return false;
+    }
     const tinyxml2::XMLElement * ruleSet = node->FirstChildElement("RuleSet");
     if (ruleSet == nullptr)
     {

--- a/model/scorecardmodel.cpp
+++ b/model/scorecardmodel.cpp
@@ -23,6 +23,11 @@
 // This generates Lua based on a scorecard, the simplest model (and possibly least useful) type.
 bool ScorecardModel::parse(AstBuilder & builder, const tinyxml2::XMLElement * node, PMMLDocument::ModelConfig & config)
 {
+    if (config.contributionsTable)
+    {
+        builder.parsingError("--contributions is only supported on tree models and additive ensembles thereof", node->GetLineNum());
+        return false;
+    }
     if (config.function != PMMLDocument::FUNCTION_REGRESSION)
     {
         builder.parsingError("Scorecard model must be a regression function", node->GetLineNum());

--- a/model/supportvectormachine.cpp
+++ b/model/supportvectormachine.cpp
@@ -686,6 +686,11 @@ bool parseWithKernel(AstBuilder & builder, const tinyxml2::XMLElement * node, co
 bool SupportVectorMachine::parse(AstBuilder & builder, const tinyxml2::XMLElement * node, PMMLDocument::ModelConfig & config)
 {
     ASSERT_AST_BUILDER_ONE_NEW_NODE(builder);
+    if (config.contributionsTable)
+    {
+        builder.parsingError("--contributions is only supported on tree models and additive ensembles thereof", node->GetLineNum());
+        return false;
+    }
     if (node->FirstChildElement("LinearKernelType"))
     {
         LinearKernel kernel;
@@ -724,4 +729,3 @@ bool SupportVectorMachine::parse(AstBuilder & builder, const tinyxml2::XMLElemen
         return false;
     }
 }
-

--- a/model/treemodel.cpp
+++ b/model/treemodel.cpp
@@ -61,13 +61,38 @@ namespace
     struct TreeConfig
     {
         PMMLDocument::ModelConfig & config;
+        PMMLDocument::ConstFieldDescriptionPtr contributionsTable;
+        PMMLDocument::ConstFieldDescriptionPtr biasAccumulator;
         bool returnLastPrediction = false;
         MissingValueStrategy missingValueStrategy = MVS_NONE;
         PMMLDocument::ConstFieldDescriptionPtr totalNumberOfRecords;
         const char * missingValuePenalty = nullptr;
         PMMLDocument::ConstFieldDescriptionPtr totalMissingValuePenalty;
-        TreeConfig(PMMLDocument::ModelConfig & c) : config(c) {}
+        TreeConfig(PMMLDocument::ModelConfig & c) : config(c), contributionsTable(c.contributionsTable), biasAccumulator(c.biasAccumulator) {}
     };
+
+    const char * scoreOrZero(const tinyxml2::XMLElement * node)
+    {
+        // TODO: Missing internal-node scores make path attribution degenerate for non-JPMML-XGBoost PMML.
+        const char * score = node ? node->Attribute("score") : nullptr;
+        return score ? score : "0";
+    }
+
+    void addContribution(AstBuilder & builder, PMMLDocument::ConstFieldDescriptionPtr contributionsTable,
+                         const char * fieldName, const char * parentScore, const char * childScore)
+    {
+        builder.constant(fieldName, PMMLDocument::TYPE_STRING);
+        builder.fieldIndirect(contributionsTable, 1);
+        builder.defaultValue("0");
+
+        builder.constant(childScore, PMMLDocument::TYPE_NUMBER);
+        builder.constant(parentScore, PMMLDocument::TYPE_NUMBER);
+        builder.function(Function::functionTable.names.minus, 2);
+        builder.function(Function::functionTable.names.plus, 2);
+
+        builder.constant(fieldName, PMMLDocument::TYPE_STRING);
+        builder.assignIndirect(contributionsTable, 1);
+    }
     
     bool parseTreeNode(AstBuilder & builder, const tinyxml2::XMLElement * node, TreeConfig & config)
     {
@@ -130,6 +155,24 @@ namespace
             if (!parseTreeNode(builder, childNode, config))
             {
                 return false;
+            }
+
+            if (config.contributionsTable)
+            {
+                if (strcmp(predicate->Name(), "SimplePredicate") == 0)
+                {
+                    if (const char * fieldName = predicate->Attribute("field"))
+                    {
+                        AstNode bodyNode = builder.popNode();
+                        addContribution(builder, config.contributionsTable, fieldName, scoreOrZero(node), scoreOrZero(childNode));
+                        builder.pushNode(std::move(bodyNode));
+                        builder.block(2);
+                    }
+                }
+                else
+                {
+                    // JPMML-XGBoost split nodes use SimplePredicate; True/False/Compound/SimpleSet do not carry path attribution here.
+                }
             }
             
             // Add a penalty clause.
@@ -553,6 +596,17 @@ bool TreeModel::parse(AstBuilder & builder, const tinyxml2::XMLElement * node,
         treeConfig.totalMissingValuePenalty = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "missingValuePenalty");
         builder.constant("1", PMMLDocument::TYPE_NUMBER);
         builder.declare(treeConfig.totalMissingValuePenalty, AstBuilder::HAS_INITIAL_VALUE);
+        blockSize++;
+    }
+
+    if (treeConfig.contributionsTable && treeConfig.biasAccumulator)
+    {
+        const tinyxml2::XMLElement * rootNode = node->FirstChildElement("Node");
+        builder.field(treeConfig.biasAccumulator);
+        builder.defaultValue("0");
+        builder.constant(scoreOrZero(rootNode), PMMLDocument::TYPE_NUMBER);
+        builder.function(Function::functionTable.names.plus, 2);
+        builder.assign(treeConfig.biasAccumulator);
         blockSize++;
     }
     

--- a/unit_tests/XGBoostBinaryLogistic.pmml
+++ b/unit_tests/XGBoostBinaryLogistic.pmml
@@ -1,0 +1,2354 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<PMML xmlns="http://www.dmg.org/PMML-4_4" xmlns:data="http://jpmml.org/jpmml-model/InlineTable" version="4.4">
+	<Header>
+		<Application name="JPMML-XGBoost command-line application" version="1.9.8"/>
+		<Timestamp>2026-06-10T23:18:29Z</Timestamp>
+	</Header>
+	<DataDictionary>
+		<DataField name="_target" optype="categorical" dataType="integer">
+			<Value value="0"/>
+			<Value value="1"/>
+		</DataField>
+		<DataField name="median_age_Fname" optype="continuous" dataType="float">
+			<Value value="NaN" property="missing"/>
+		</DataField>
+		<DataField name="q60_age_Fname" optype="continuous" dataType="float">
+			<Value value="NaN" property="missing"/>
+		</DataField>
+		<DataField name="q70_age_Fname" optype="continuous" dataType="float">
+			<Value value="NaN" property="missing"/>
+		</DataField>
+		<DataField name="q80_age_Fname" optype="continuous" dataType="float">
+			<Value value="NaN" property="missing"/>
+		</DataField>
+		<DataField name="q90_age_Fname" optype="continuous" dataType="float">
+			<Value value="NaN" property="missing"/>
+		</DataField>
+	</DataDictionary>
+	<MiningModel functionName="classification" algorithmName="XGBoost (GBTree)" x-mathContext="float">
+		<MiningSchema>
+			<MiningField name="_target" usageType="target"/>
+			<MiningField name="median_age_Fname"/>
+			<MiningField name="q60_age_Fname"/>
+			<MiningField name="q70_age_Fname"/>
+			<MiningField name="q80_age_Fname"/>
+			<MiningField name="q90_age_Fname"/>
+		</MiningSchema>
+		<Segmentation multipleModelMethod="modelChain" missingPredictionTreatment="returnMissing">
+			<Segment id="1">
+				<True/>
+				<MiningModel functionName="regression" x-mathContext="float">
+					<MiningSchema>
+						<MiningField name="median_age_Fname"/>
+						<MiningField name="q60_age_Fname"/>
+						<MiningField name="q70_age_Fname"/>
+						<MiningField name="q80_age_Fname"/>
+						<MiningField name="q90_age_Fname"/>
+					</MiningSchema>
+					<Output>
+						<OutputField name="xgbValue" optype="continuous" dataType="float" isFinalResult="false"/>
+					</Output>
+					<Segmentation multipleModelMethod="sum" missingPredictionTreatment="returnMissing">
+						<Segment id="1">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.021139603">
+									<True/>
+									<Node score="-0.013965824">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="67.17043"/>
+										<Node score="-0.025549354">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="58.59548"/>
+											<Node score="-0.031062497">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="50.091717"/>
+												<Node score="-0.032664347">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="44.594112"/>
+												</Node>
+											</Node>
+											<Node score="-0.028696852">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="55.471596"/>
+											</Node>
+										</Node>
+										<Node score="-0.020277778">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="62.475018"/>
+											<Node score="-0.022547586">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.19644"/>
+											</Node>
+										</Node>
+										<Node score="-0.017657004">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.69815"/>
+										</Node>
+									</Node>
+									<Node score="0.001977785">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="63.835728"/>
+										<Node score="-0.006744915">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="59.356606"/>
+											<Node score="-0.011244463">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="54.96783"/>
+											</Node>
+										</Node>
+										<Node score="-0.001285859">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="61.92197"/>
+										</Node>
+									</Node>
+									<Node score="0.011969712">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="69.735794"/>
+										<Node score="0.006559084">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="66.96783"/>
+										</Node>
+									</Node>
+									<Node score="0.0149926655">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="2">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q70_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.020751435">
+									<True/>
+									<Node score="-0.01259196">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="62.89117"/>
+										<Node score="-0.027422769">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="52.202602"/>
+											<Node score="-0.030896287">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="43.430527"/>
+												<Node score="-0.03210719">
+													<SimplePredicate field="q70_age_Fname" operator="lessThan" value="36.73648"/>
+												</Node>
+											</Node>
+											<Node score="-0.029313114">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="46.77344"/>
+											</Node>
+										</Node>
+										<Node score="-0.01990132">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="58.141"/>
+											<Node score="-0.022824813">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="56.07666"/>
+											</Node>
+										</Node>
+										<Node score="-0.016474448">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.32238"/>
+										</Node>
+									</Node>
+									<Node score="0.0024274858">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="64.31212"/>
+										<Node score="-0.0054201335">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.046543"/>
+											<Node score="-0.009826266">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="65.3963"/>
+											</Node>
+										</Node>
+										<Node score="-8.641225E-4">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="62.272415"/>
+										</Node>
+									</Node>
+									<Node score="0.012597875">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="71.25256"/>
+										<Node score="0.006791997">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="66.96783"/>
+										</Node>
+									</Node>
+									<Node score="0.016261974">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="3">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q80_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.019863913">
+									<True/>
+									<Node score="-0.013600079">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="67.1896"/>
+										<Node score="-0.02503483">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="63.904175"/>
+											<Node score="-0.030392285">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.2731"/>
+												<Node score="-0.03193655">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.713894"/>
+												</Node>
+											</Node>
+											<Node score="-0.027784653">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="61.853523"/>
+											</Node>
+										</Node>
+										<Node score="-0.020891136">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="62.417522"/>
+											<Node score="-0.023340108">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.342915"/>
+											</Node>
+										</Node>
+										<Node score="-0.01731995">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.67351"/>
+										</Node>
+									</Node>
+									<Node score="0.0018103354">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="77.82889"/>
+										<Node score="-0.008112713">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="72.34497"/>
+											<Node score="-3.6882292E-4">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="72.64887"/>
+											</Node>
+										</Node>
+										<Node score="0.009807971">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="77.24298"/>
+										</Node>
+									</Node>
+									<Node score="0.010168555">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="82.79808"/>
+										<Node score="0.017144596">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="82.25873"/>
+										</Node>
+									</Node>
+									<Node score="0.015100486">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="86.83915"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="4">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q80_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.019928262">
+									<True/>
+									<Node score="-0.01319725">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="67.77002"/>
+										<Node score="-0.024618475">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="63.904175"/>
+											<Node score="-0.029391447">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.601643"/>
+												<Node score="-0.031237312">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="53.127995"/>
+												</Node>
+											</Node>
+											<Node score="-0.027229816">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="61.853523"/>
+											</Node>
+										</Node>
+										<Node score="-0.0202752">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="62.55989"/>
+											<Node score="-0.02281528">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.70979"/>
+											</Node>
+										</Node>
+										<Node score="-0.016869089">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.678986"/>
+										</Node>
+									</Node>
+									<Node score="0.0013246089">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="77.82889"/>
+										<Node score="-0.007876877">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="72.34497"/>
+											<Node score="-5.39093E-5">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="72.67625"/>
+											</Node>
+										</Node>
+										<Node score="0.006152582">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="79.41136"/>
+										</Node>
+									</Node>
+									<Node score="0.009999483">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="82.79808"/>
+										<Node score="0.016937202">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="82.25873"/>
+										</Node>
+									</Node>
+									<Node score="0.015100279">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="87.81109"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="5">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q60_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.022864241">
+									<True/>
+									<Node score="-0.01141063">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="60.06571"/>
+										<Node score="-0.024425441">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="49.379875"/>
+											<Node score="-0.029255612">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="40.459957"/>
+												<Node score="-0.030364558">
+													<SimplePredicate field="q60_age_Fname" operator="lessThan" value="33.13347"/>
+												</Node>
+											</Node>
+											<Node score="-0.026913274">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="44.821354"/>
+											</Node>
+										</Node>
+										<Node score="-0.018213637">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="56.019165"/>
+											<Node score="-0.021301106">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="51.356606"/>
+											</Node>
+										</Node>
+										<Node score="-0.01445585">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="58.028748"/>
+										</Node>
+									</Node>
+									<Node score="0.0040938393">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.24298"/>
+										<Node score="-0.0039174915">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.648872"/>
+											<Node score="-0.007717701">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.321697"/>
+											</Node>
+										</Node>
+										<Node score="-5.8534447E-6">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="63.195072"/>
+										</Node>
+									</Node>
+									<Node score="0.01232276">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="71.25256"/>
+										<Node score="0.008158846">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.018294672">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="76.95551"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="6">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q70_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.019877048">
+									<True/>
+									<Node score="-0.010991678">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="63.430527"/>
+										<Node score="-0.024188166">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="63.942505"/>
+											<Node score="-0.029018845">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.30048"/>
+												<Node score="-0.03052534">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.815193"/>
+												</Node>
+											</Node>
+											<Node score="-0.026603479">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="61.57974"/>
+											</Node>
+										</Node>
+										<Node score="-0.018284202">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="58.141"/>
+											<Node score="-0.021358553">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="68.50924"/>
+											</Node>
+										</Node>
+										<Node score="-0.015281991">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.431896"/>
+										</Node>
+									</Node>
+									<Node score="4.019986E-4">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="73.06229"/>
+										<Node score="-0.0042725476">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="68.18343"/>
+											<Node score="-0.00842201">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="65.3963"/>
+											</Node>
+										</Node>
+										<Node score="0.0072037727">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="79.1102"/>
+										</Node>
+									</Node>
+									<Node score="0.012652868">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="78.8282"/>
+										<Node score="0.008382469">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="75.780975"/>
+										</Node>
+									</Node>
+									<Node score="0.017002145">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="83.512665"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="7">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q70_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.01880192">
+									<True/>
+									<Node score="-0.011522148">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="62.89117"/>
+										<Node score="-0.02531009">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="52.42163"/>
+											<Node score="-0.028618021">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="43.195072"/>
+												<Node score="-0.029741554">
+													<SimplePredicate field="q70_age_Fname" operator="lessThan" value="36.755646"/>
+												</Node>
+											</Node>
+											<Node score="-0.027192742">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="46.77344"/>
+											</Node>
+										</Node>
+										<Node score="-0.018398734">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="58.141"/>
+											<Node score="-0.021112127">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="56.054756"/>
+											</Node>
+										</Node>
+										<Node score="-0.015086606">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.500343"/>
+										</Node>
+									</Node>
+									<Node score="0.003117919">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.39973"/>
+										<Node score="-0.0056419">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="63.331963"/>
+											<Node score="-0.00917426">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.21013"/>
+											</Node>
+										</Node>
+										<Node score="-6.3906383E-4">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.008463527">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="73.27858"/>
+										<Node score="0.012913693">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="72.410675"/>
+										</Node>
+									</Node>
+									<Node score="0.014249832">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="8">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q70_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.018501204">
+									<True/>
+									<Node score="-0.010167592">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="60.197124"/>
+										<Node score="-0.021862026">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="54.40657"/>
+											<Node score="-0.02692129">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="46.77344"/>
+												<Node score="-0.028897082">
+													<SimplePredicate field="q70_age_Fname" operator="lessThan" value="42.387405"/>
+												</Node>
+											</Node>
+											<Node score="-0.024977677">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="52.095825"/>
+											</Node>
+										</Node>
+										<Node score="-0.016381497">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="60.4052"/>
+											<Node score="-0.019656483">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="57.41547"/>
+											</Node>
+										</Node>
+										<Node score="-0.0136509">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.891853"/>
+										</Node>
+									</Node>
+									<Node score="0.0031610837">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.39973"/>
+										<Node score="-0.004175084">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="63.66598"/>
+											<Node score="-0.0073117213">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.92471"/>
+											</Node>
+										</Node>
+										<Node score="-3.1460304E-4">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.00852954">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="73.28679"/>
+										<Node score="0.014087123">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="71.66872"/>
+										</Node>
+									</Node>
+									<Node score="0.014059842">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="9">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.020177564">
+									<True/>
+									<Node score="-0.010340366">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.950718"/>
+										<Node score="-0.021984968">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.25804"/>
+											<Node score="-0.02663208">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="53.319645"/>
+												<Node score="-0.028802771">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="46.896645"/>
+												</Node>
+											</Node>
+											<Node score="-0.024508147">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="56.14237"/>
+											</Node>
+										</Node>
+										<Node score="-0.015728308">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.870636"/>
+											<Node score="-0.019365206">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.930183"/>
+											</Node>
+										</Node>
+										<Node score="-0.013160597">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="56.454483"/>
+										</Node>
+									</Node>
+									<Node score="0.0030678252">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.39973"/>
+										<Node score="-0.004104481">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="63.687885"/>
+											<Node score="-0.0074602263">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.0397"/>
+											</Node>
+										</Node>
+										<Node score="-3.6978477E-4">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.012208872">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="74.2998"/>
+										<Node score="0.008200577">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="72.70911"/>
+										</Node>
+									</Node>
+									<Node score="0.015952228">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="79.88501"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="10">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.01984223">
+									<True/>
+									<Node score="-0.010666374">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="60.221767"/>
+										<Node score="-0.022347055">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="64.095825"/>
+											<Node score="-0.027456699">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.52772"/>
+												<Node score="-0.02890743">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.85079"/>
+												</Node>
+											</Node>
+											<Node score="-0.024880396">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="62.07803"/>
+											</Node>
+										</Node>
+										<Node score="-0.015129435">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="55.58111"/>
+											<Node score="-0.019441182">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="70.26694"/>
+											</Node>
+										</Node>
+										<Node score="-0.015097745">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="69.39356"/>
+										</Node>
+									</Node>
+									<Node score="0.0030308478">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.39973"/>
+										<Node score="-0.003713398">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="64.12594"/>
+											<Node score="-0.007132331">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.07529"/>
+											</Node>
+										</Node>
+										<Node score="-9.4368734E-5">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.012073653">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="74.2998"/>
+										<Node score="0.008083454">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="72.70911"/>
+										</Node>
+									</Node>
+									<Node score="0.015740244">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="79.88501"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="11">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q60_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.018257597">
+									<True/>
+									<Node score="-0.010282543">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="60.22998"/>
+										<Node score="-0.025589883">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="49.598904"/>
+											<Node score="-0.0251875">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="42.973305"/>
+												<Node score="-0.02738448">
+													<SimplePredicate field="q60_age_Fname" operator="lessThan" value="40.125942"/>
+												</Node>
+											</Node>
+											<Node score="-0.021865692">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="44.950035"/>
+											</Node>
+										</Node>
+										<Node score="-0.016565362">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="55.96441"/>
+											<Node score="-0.019420883">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="51.356606"/>
+											</Node>
+										</Node>
+										<Node score="-0.013257065">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="58.028748"/>
+										</Node>
+									</Node>
+									<Node score="0.0037220058">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.36071"/>
+										<Node score="-0.0037678564">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.424366"/>
+											<Node score="-0.006922103">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.17659"/>
+											</Node>
+										</Node>
+										<Node score="-1.669271E-5">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="63.192333"/>
+										</Node>
+									</Node>
+									<Node score="0.011059168">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="71.25256"/>
+										<Node score="0.006834722">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.01437"/>
+										</Node>
+									</Node>
+									<Node score="0.01416854">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="12">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.017418522">
+									<True/>
+									<Node score="-0.0097825285">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.980835"/>
+										<Node score="-0.021216419">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.342915"/>
+											<Node score="-0.026802987">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="50.07255"/>
+												<Node score="-0.028142642">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="40.32854"/>
+												</Node>
+											</Node>
+											<Node score="-0.024292018">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="55.778233"/>
+											</Node>
+										</Node>
+										<Node score="-0.015009405">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.681725"/>
+											<Node score="-0.018379414">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="62.236824"/>
+											</Node>
+										</Node>
+										<Node score="-0.0125882495">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="56.55852"/>
+										</Node>
+									</Node>
+									<Node score="0.0029640899">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.31485"/>
+										<Node score="-0.003489258">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="64.19713"/>
+											<Node score="-0.006899112">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.19302"/>
+											</Node>
+										</Node>
+										<Node score="-7.5119395E-5">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.0070615923">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="73.28679"/>
+										<Node score="0.011360738">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="76.89528"/>
+										</Node>
+									</Node>
+									<Node score="0.013121301">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="13">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q70_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.019017264">
+									<True/>
+									<Node score="-0.010473551">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="62.89117"/>
+										<Node score="-0.0230185">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="52.42163"/>
+											<Node score="-0.026321495">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="43.419575"/>
+												<Node score="-0.027526103">
+													<SimplePredicate field="q70_age_Fname" operator="lessThan" value="36.881588"/>
+												</Node>
+											</Node>
+											<Node score="-0.024758153">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="48.358658"/>
+											</Node>
+										</Node>
+										<Node score="-0.016787529">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="58.141"/>
+											<Node score="-0.019300554">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="56.054756"/>
+											</Node>
+										</Node>
+										<Node score="-0.013716683">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.46475"/>
+										</Node>
+									</Node>
+									<Node score="0.0028502173">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.31485"/>
+										<Node score="-0.0047228313">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="63.178646"/>
+											<Node score="-0.008089373">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.50308"/>
+											</Node>
+										</Node>
+										<Node score="-5.4135144E-4">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.011510327">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="74.2998"/>
+										<Node score="0.007647268">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="72.70911"/>
+										</Node>
+									</Node>
+									<Node score="0.014997832">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="79.88501"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="14">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q70_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.015757209">
+									<True/>
+									<Node score="-0.01148355">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="62.762493"/>
+										<Node score="-0.022234015">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="57.29774"/>
+											<Node score="-0.02637038">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="49.141685"/>
+												<Node score="-0.027545713">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="39.27447"/>
+												</Node>
+											</Node>
+											<Node score="-0.024266675">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="54.321697"/>
+											</Node>
+										</Node>
+										<Node score="-0.017554956">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="62.38193"/>
+											<Node score="-0.01979585">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.9206"/>
+											</Node>
+										</Node>
+										<Node score="-0.014218718">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="65.5551"/>
+										</Node>
+									</Node>
+									<Node score="4.3476903E-4">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="72.1451"/>
+										<Node score="-0.0039034367">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="68.14784"/>
+											<Node score="-0.00805237">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="65.16632"/>
+											</Node>
+										</Node>
+										<Node score="0.0066278535">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="72.58316"/>
+										</Node>
+									</Node>
+									<Node score="0.0053016264">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="75.980835"/>
+										<Node score="0.010390562">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="76.89528"/>
+										</Node>
+									</Node>
+									<Node score="0.011246351">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="78.8282"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="15">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.019940281">
+									<True/>
+									<Node score="-0.008655628">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="55.8193"/>
+										<Node score="-0.020807285">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="64.02738"/>
+											<Node score="-0.025842559">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.423683"/>
+												<Node score="-0.027234318">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.675564"/>
+												</Node>
+											</Node>
+											<Node score="-0.023326162">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="62.020535"/>
+											</Node>
+										</Node>
+										<Node score="-0.014344729">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="72.80766"/>
+											<Node score="-0.01785766">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="69.0705"/>
+											</Node>
+										</Node>
+										<Node score="-0.012420157">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="50.872005"/>
+										</Node>
+									</Node>
+									<Node score="0.002490856">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.026695"/>
+										<Node score="-0.0050153374">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.36961"/>
+											<Node score="-0.010459736">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="71.321014"/>
+											</Node>
+										</Node>
+										<Node score="-5.4683065E-4">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="62.477757"/>
+										</Node>
+									</Node>
+									<Node score="0.010453114">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="71.25256"/>
+										<Node score="0.0061128493">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.01437"/>
+										</Node>
+									</Node>
+									<Node score="0.015702266">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="77.00479"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="16">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.0163941">
+									<True/>
+									<Node score="-0.009298489">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.74264"/>
+										<Node score="-0.02039493">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="58.683094"/>
+											<Node score="-0.02561427">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="50.069817"/>
+												<Node score="-0.026916584">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="39.37851"/>
+												</Node>
+											</Node>
+											<Node score="-0.023216965">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="55.471596"/>
+											</Node>
+										</Node>
+										<Node score="-0.014140404">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.6653"/>
+											<Node score="-0.01754407">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="62.19028"/>
+											</Node>
+										</Node>
+										<Node score="-0.011828023">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="56.48734"/>
+										</Node>
+									</Node>
+									<Node score="0.0026856412">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.31759"/>
+										<Node score="-0.0034853853">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="64.00548"/>
+											<Node score="-0.006646012">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.993156"/>
+											</Node>
+										</Node>
+										<Node score="-1.221908E-4">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.0066542346">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="73.28679"/>
+										<Node score="0.011038399">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="76.73922"/>
+										</Node>
+									</Node>
+									<Node score="0.0123821935">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="17">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.016172387">
+									<True/>
+									<Node score="-0.009642803">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.805614"/>
+										<Node score="-0.020444863">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="63.9206"/>
+											<Node score="-0.025186734">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.549625"/>
+												<Node score="-0.026637191">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.828884"/>
+												</Node>
+											</Node>
+											<Node score="-0.02278997">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="61.853523"/>
+											</Node>
+										</Node>
+										<Node score="-0.013833474">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="69.456535"/>
+											<Node score="-0.017660856">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="55.687885"/>
+											</Node>
+										</Node>
+										<Node score="-0.013775245">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="55.18138"/>
+										</Node>
+									</Node>
+									<Node score="2.1305111E-4">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.33949"/>
+										<Node score="-0.0032696181">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="64.30116"/>
+											<Node score="-0.0064542396">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.146477"/>
+											</Node>
+										</Node>
+										<Node score="0.0038858133">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="78.01232"/>
+										</Node>
+									</Node>
+									<Node score="0.006269281">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="73.28679"/>
+										<Node score="0.010472067">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="82.2423"/>
+										</Node>
+									</Node>
+									<Node score="0.012174779">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="18">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.017719554">
+									<True/>
+									<Node score="-0.008911121">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.622177"/>
+										<Node score="-0.01970322">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.25804"/>
+											<Node score="-0.02465244">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="50.083504"/>
+												<Node score="-0.02601039">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="44.684464"/>
+												</Node>
+											</Node>
+											<Node score="-0.022525482">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="55.509926"/>
+											</Node>
+										</Node>
+										<Node score="-0.013714476">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.681725"/>
+											<Node score="-0.016993761">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.930183"/>
+											</Node>
+										</Node>
+										<Node score="-0.011438948">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="56.654346"/>
+										</Node>
+									</Node>
+									<Node score="0.0026609295">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.37782"/>
+										<Node score="-0.0035017678">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="63.775497"/>
+											<Node score="-0.006538036">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.19302"/>
+											</Node>
+										</Node>
+										<Node score="-2.5845264E-4">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.010400423">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="74.2998"/>
+										<Node score="0.006895177">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="72.413414"/>
+										</Node>
+									</Node>
+									<Node score="0.013915553">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="79.88501"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="19">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q80_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.015954351">
+									<True/>
+									<Node score="-0.010382181">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="66.72416"/>
+										<Node score="-0.021370085">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="62.417522"/>
+											<Node score="-0.024938814">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="56.11225"/>
+												<Node score="-0.026086617">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.85079"/>
+												</Node>
+											</Node>
+											<Node score="-0.02306436">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="60.563995"/>
+											</Node>
+										</Node>
+										<Node score="-0.016658142">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="62.417522"/>
+											<Node score="-0.019106952">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="65.70568"/>
+											</Node>
+										</Node>
+										<Node score="-0.013238198">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.870636"/>
+										</Node>
+									</Node>
+									<Node score="9.537653E-4">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="77.82889"/>
+										<Node score="-0.0068849926">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="70.850105"/>
+											<Node score="-0.0025515219">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="72.49829"/>
+											</Node>
+										</Node>
+										<Node score="0.010460895">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="75.441475"/>
+										</Node>
+									</Node>
+									<Node score="0.0077075465">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="82.79808"/>
+										<Node score="0.013917835">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="82.25873"/>
+										</Node>
+									</Node>
+									<Node score="0.011497624">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="87.81109"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="20">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.015445961">
+									<True/>
+									<Node score="-0.009191636">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.718002"/>
+										<Node score="-0.019523645">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="64.095825"/>
+											<Node score="-0.024403417">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.49213"/>
+												<Node score="-0.025821788">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.85079"/>
+												</Node>
+											</Node>
+											<Node score="-0.02188376">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="62.143738"/>
+											</Node>
+										</Node>
+										<Node score="-0.012875519">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="55.613964"/>
+											<Node score="-0.016746527">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="70.26694"/>
+											</Node>
+										</Node>
+										<Node score="-0.013065652">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="69.43737"/>
+										</Node>
+									</Node>
+									<Node score="0.002626998">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.39973"/>
+										<Node score="-0.003604347">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="63.838467"/>
+											<Node score="-0.0064334124">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.74675"/>
+											</Node>
+										</Node>
+										<Node score="-2.180857E-4">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.0049309717">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="72.70911"/>
+										<Node score="0.0101145515">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="81.79056"/>
+										</Node>
+									</Node>
+									<Node score="0.011162949">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="21">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q60_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.018619409">
+									<True/>
+									<Node score="-0.011434419">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.542778"/>
+										<Node score="-0.022853347">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="49.379875"/>
+											<Node score="-0.022237156">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="42.973305"/>
+												<Node score="-0.024372315">
+													<SimplePredicate field="q60_age_Fname" operator="lessThan" value="40.262833"/>
+												</Node>
+											</Node>
+											<Node score="-0.019158795">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="44.81588"/>
+											</Node>
+										</Node>
+										<Node score="-0.014273581">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="56.03833"/>
+											<Node score="-0.016782984">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="51.356606"/>
+											</Node>
+										</Node>
+										<Node score="-0.009098186">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="54.03422"/>
+										</Node>
+									</Node>
+									<Node score="0.002183436">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.026695"/>
+										<Node score="-0.0033932512">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.36961"/>
+											<Node score="-0.0062751994">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.946613"/>
+											</Node>
+										</Node>
+										<Node score="-6.609925E-4">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="62.376453"/>
+										</Node>
+									</Node>
+									<Node score="0.01000023">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+										<Node score="0.0060317423">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.015276196">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="76.93635"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="22">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.015722016">
+									<True/>
+									<Node score="-0.009810398">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="66.95962"/>
+										<Node score="-0.020286104">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="57.366188"/>
+											<Node score="-0.024086634">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="49.092403"/>
+												<Node score="-0.025242684">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="40.325806"/>
+												</Node>
+											</Node>
+											<Node score="-0.022263924">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="53.659138"/>
+											</Node>
+										</Node>
+										<Node score="-0.015849391">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.97399"/>
+											<Node score="-0.01779454">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.641342"/>
+											</Node>
+										</Node>
+										<Node score="-0.012747669">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.8679"/>
+										</Node>
+									</Node>
+									<Node score="0.0013882803">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="64.31212"/>
+										<Node score="-0.0050892727">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="58.87748"/>
+											<Node score="-0.007973931">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="54.96783"/>
+											</Node>
+										</Node>
+										<Node score="-0.0013405917">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="61.84531"/>
+										</Node>
+									</Node>
+									<Node score="0.008492408">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="69.735794"/>
+										<Node score="0.0046279635">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="66.83094"/>
+										</Node>
+									</Node>
+									<Node score="0.010978986">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="23">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q60_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.01811626">
+									<True/>
+									<Node score="-0.008685371">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.685146"/>
+										<Node score="-0.01901212">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="49.54141"/>
+											<Node score="-0.02340091">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="40.37235"/>
+												<Node score="-0.024490707">
+													<SimplePredicate field="q60_age_Fname" operator="lessThan" value="32.594112"/>
+												</Node>
+											</Node>
+											<Node score="-0.0213169">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="44.821354"/>
+											</Node>
+										</Node>
+										<Node score="-0.017132059">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="55.55647"/>
+											<Node score="-0.014185756">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="50.59548"/>
+											</Node>
+										</Node>
+										<Node score="-0.011129743">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="58.028748"/>
+										</Node>
+									</Node>
+									<Node score="0.0033932975">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.36071"/>
+										<Node score="-0.0028656276">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="61.103355"/>
+											<Node score="-0.0059894635">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.17659"/>
+											</Node>
+										</Node>
+										<Node score="2.881083E-4">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="63.55647"/>
+										</Node>
+									</Node>
+									<Node score="0.00942461">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="71.25256"/>
+										<Node score="0.0060067694">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.014059966">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="77.01574"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="24">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.017706357">
+									<True/>
+									<Node score="-0.007508084">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="55.8193"/>
+										<Node score="-0.0184733">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="64.095825"/>
+											<Node score="-0.023439106">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.366188"/>
+												<Node score="-0.024868794">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.84531"/>
+												</Node>
+											</Node>
+											<Node score="-0.020955572">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="62.160164"/>
+											</Node>
+										</Node>
+										<Node score="-0.012529767">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="72.911705"/>
+											<Node score="-0.015749183">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="68.89802"/>
+											</Node>
+										</Node>
+										<Node score="-0.010625552">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="50.88022"/>
+										</Node>
+									</Node>
+									<Node score="0.0028692824">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.24298"/>
+										<Node score="-0.004534842">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.40794"/>
+											<Node score="-0.009835572">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="69.63724"/>
+											</Node>
+										</Node>
+										<Node score="-7.8979494E-5">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="63.195072"/>
+										</Node>
+									</Node>
+									<Node score="0.009519141">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+										<Node score="0.005847753">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.014595559">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="76.97468"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="25">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.017666304">
+									<True/>
+									<Node score="-0.0073638735">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="55.8193"/>
+										<Node score="-0.018413328">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="63.983574"/>
+											<Node score="-0.022787474">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.52772"/>
+												<Node score="-0.024466308">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="53.127995"/>
+												</Node>
+											</Node>
+											<Node score="-0.020758308">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="61.891853"/>
+											</Node>
+										</Node>
+										<Node score="-0.012375067">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="72.89802"/>
+											<Node score="-0.015517194">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="69.01301"/>
+											</Node>
+										</Node>
+										<Node score="-0.010453506">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="50.88022"/>
+										</Node>
+									</Node>
+									<Node score="0.00291918">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.27858"/>
+										<Node score="-0.004163367">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.501026"/>
+											<Node score="-0.00851475">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="71.41958"/>
+											</Node>
+										</Node>
+										<Node score="-1.007256E-4">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="63.192333"/>
+										</Node>
+									</Node>
+									<Node score="0.009459822">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+										<Node score="0.005888743">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.014320614">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="77.07871"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="26">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q70_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.01309902">
+									<True/>
+									<Node score="-0.011272521">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.89733"/>
+										<Node score="-0.019403309">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="63.282684"/>
+											<Node score="-0.023247886">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="56.11225"/>
+												<Node score="-0.024421943">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.85079"/>
+												</Node>
+											</Node>
+											<Node score="-0.02139332">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="60.402466"/>
+											</Node>
+										</Node>
+										<Node score="-0.013946069">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="57.41547"/>
+											<Node score="-0.016794084">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="67.94798"/>
+											</Node>
+										</Node>
+										<Node score="-0.016129274">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="64.82683"/>
+										</Node>
+									</Node>
+									<Node score="-4.202565E-4">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="69.60712"/>
+										<Node score="-0.005437703">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="65.31143"/>
+											<Node score="-0.0073982463">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="64.410675"/>
+											</Node>
+										</Node>
+										<Node score="-0.003136083">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="68.14784"/>
+										</Node>
+									</Node>
+									<Node score="0.0018957035">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="75.77824"/>
+										<Node score="0.0061983364">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="81.86174"/>
+										</Node>
+									</Node>
+									<Node score="0.009201507">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="78.8282"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="27">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.014744696">
+									<True/>
+									<Node score="-0.00717198">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="55.778233"/>
+										<Node score="-0.017883437">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="63.904175"/>
+											<Node score="-0.022939911">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="56.33402"/>
+												<Node score="-0.024215212">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.85079"/>
+												</Node>
+											</Node>
+											<Node score="-0.020473158">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="62.143738"/>
+											</Node>
+										</Node>
+										<Node score="-0.01261934">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="72.911705"/>
+											<Node score="-0.016111072">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="66.95688"/>
+											</Node>
+										</Node>
+										<Node score="-0.010244827">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="50.88022"/>
+										</Node>
+									</Node>
+									<Node score="0.0019016494">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.02122"/>
+										<Node score="-0.0047521666">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.032856"/>
+											<Node score="-0.01200696">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="66.96783"/>
+											</Node>
+										</Node>
+										<Node score="-9.071396E-4">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="62.009583"/>
+										</Node>
+									</Node>
+									<Node score="0.008839993">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="71.26078"/>
+										<Node score="0.0054387785">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.011118447">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="28">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.01389327">
+									<True/>
+									<Node score="-0.00807937">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.74264"/>
+										<Node score="-0.017473549">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.25804"/>
+											<Node score="-0.022598436">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="50.091717"/>
+												<Node score="-0.023984589">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="39.446953"/>
+												</Node>
+											</Node>
+											<Node score="-0.020217912">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="55.471596"/>
+											</Node>
+										</Node>
+										<Node score="-0.0121300155">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.172485"/>
+											<Node score="-0.014838407">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.930183"/>
+											</Node>
+										</Node>
+										<Node score="-0.010757692">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="65.59617"/>
+										</Node>
+									</Node>
+									<Node score="0.0022954792">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.31485"/>
+										<Node score="-0.0031349726">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="63.720737"/>
+											<Node score="-0.005638558">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.74675"/>
+											</Node>
+										</Node>
+										<Node score="-1.909628E-4">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										</Node>
+									</Node>
+									<Node score="0.0053373934">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="73.34702"/>
+										<Node score="0.009459961">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="76.73922"/>
+										</Node>
+									</Node>
+									<Node score="0.010373119">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="29">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q70_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.014362817">
+									<True/>
+									<Node score="-0.009897101">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.859"/>
+										<Node score="-0.018656863">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="52.689938"/>
+											<Node score="-0.02222526">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="43.394936"/>
+												<Node score="-0.023433387">
+													<SimplePredicate field="q70_age_Fname" operator="lessThan" value="36.755646"/>
+												</Node>
+											</Node>
+											<Node score="-0.020460786">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="49.842575"/>
+											</Node>
+										</Node>
+										<Node score="-0.016531648">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="57.41547"/>
+											<Node score="-0.014102504">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="46.844627"/>
+											</Node>
+										</Node>
+										<Node score="-0.012023858">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="59.852158"/>
+										</Node>
+									</Node>
+									<Node score="0.0013408781">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="64.251884"/>
+										<Node score="-0.004088408">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="59.761806"/>
+											<Node score="-0.0070812968">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="64.55305"/>
+											</Node>
+										</Node>
+										<Node score="-9.5632946E-4">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="62.009583"/>
+										</Node>
+									</Node>
+									<Node score="0.0077533806">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="69.735794"/>
+										<Node score="0.004246435">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="66.96783"/>
+										</Node>
+									</Node>
+									<Node score="0.009931577">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="30">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q70_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.012460463">
+									<True/>
+									<Node score="-0.010609935">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.612595"/>
+										<Node score="-0.018816778">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="62.551678"/>
+											<Node score="-0.022557367">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="55.397675"/>
+												<Node score="-0.023650574">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.535934"/>
+												</Node>
+											</Node>
+											<Node score="-0.020600349">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="60.594112"/>
+											</Node>
+										</Node>
+										<Node score="-0.013160102">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="57.40178"/>
+											<Node score="-0.016200535">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="67.72348"/>
+											</Node>
+										</Node>
+										<Node score="-0.015106503">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="65.05955"/>
+										</Node>
+									</Node>
+									<Node score="-3.603111E-4">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="69.59617"/>
+										<Node score="-0.005020016">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="65.31143"/>
+											<Node score="-0.0070137987">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="64.410675"/>
+											</Node>
+										</Node>
+										<Node score="-0.0029168844">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="68.142365"/>
+										</Node>
+									</Node>
+									<Node score="0.0013292355">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="75.4935"/>
+										<Node score="0.0059094676">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="81.5551"/>
+										</Node>
+									</Node>
+									<Node score="0.008312849">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="78.8282"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="31">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q60_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.016493427">
+									<True/>
+									<Node score="-0.0076129944">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.718002"/>
+										<Node score="-0.017494788">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="49.409992"/>
+											<Node score="-0.021844331">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="40.262833"/>
+												<Node score="-0.023190944">
+													<SimplePredicate field="q60_age_Fname" operator="lessThan" value="29.533195"/>
+												</Node>
+											</Node>
+											<Node score="-0.019849166">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="43.830254"/>
+											</Node>
+										</Node>
+										<Node score="-0.012349536">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="56.04107"/>
+											<Node score="-0.014901927">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="51.356606"/>
+											</Node>
+										</Node>
+										<Node score="-0.009632355">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="58.028748"/>
+										</Node>
+									</Node>
+									<Node score="0.0016815369">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.026695"/>
+										<Node score="-0.0026487594">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="60.553047"/>
+											<Node score="-0.005231983">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.143738"/>
+											</Node>
+										</Node>
+										<Node score="-6.747726E-4">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="61.84805"/>
+										</Node>
+									</Node>
+									<Node score="0.008589237">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+										<Node score="0.0051638437">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.013250369">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="77.00479"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="32">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.013177294">
+									<True/>
+									<Node score="-0.008050369">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.548256"/>
+										<Node score="-0.016871264">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="64.06297"/>
+											<Node score="-0.021769604">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="57.52772"/>
+												<Node score="-0.023267027">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.85079"/>
+												</Node>
+											</Node>
+											<Node score="-0.019281743">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="61.98768"/>
+											</Node>
+										</Node>
+										<Node score="-0.010393868">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="69.12799"/>
+											<Node score="-0.01434783">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="57.204655"/>
+											</Node>
+										</Node>
+										<Node score="-0.011403257">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="53.64271"/>
+										</Node>
+									</Node>
+									<Node score="-5.8287736E-5">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="68.39973"/>
+										<Node score="-0.0027759224">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="64.00548"/>
+											<Node score="-0.00538339">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.74675"/>
+											</Node>
+										</Node>
+										<Node score="0.0028119434">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="79.10198"/>
+										</Node>
+									</Node>
+									<Node score="0.004824688">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="73.35797"/>
+										<Node score="0.008547815">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="82.13552"/>
+										</Node>
+									</Node>
+									<Node score="0.009714725">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="33">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.0129172765">
+									<True/>
+									<Node score="-0.0023316892">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="65.56332"/>
+										<Node score="-0.019565113">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="56.859684"/>
+											<Node score="-0.021703476">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="49.59069"/>
+												<Node score="-0.02303309">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="39.827515"/>
+												</Node>
+											</Node>
+											<Node score="-0.017291445">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="42.351814"/>
+											</Node>
+										</Node>
+										<Node score="-0.013814995">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.908283"/>
+											<Node score="-0.01593557">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.342915"/>
+											</Node>
+										</Node>
+										<Node score="-0.010708291">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="60.884327"/>
+										</Node>
+									</Node>
+									<Node score="-8.859896E-5">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="66.663925"/>
+										<Node score="-0.0049811057">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="61.63176"/>
+											<Node score="-0.0073923175">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="59.980835"/>
+											</Node>
+										</Node>
+										<Node score="-0.002755911">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="64.30116"/>
+										</Node>
+									</Node>
+									<Node score="0.002906236">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="72.6653"/>
+										<Node score="0.0070311916">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="76.89254"/>
+										</Node>
+									</Node>
+									<Node score="0.009202051">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="34">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q60_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.012754326">
+									<True/>
+									<Node score="-0.008598396">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="58.028748"/>
+										<Node score="-0.01802274">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="62.628338"/>
+											<Node score="-0.021739071">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="56.11225"/>
+												<Node score="-0.022945065">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.535934"/>
+												</Node>
+											</Node>
+											<Node score="-0.019770483">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="60.314854"/>
+											</Node>
+										</Node>
+										<Node score="-0.013218532">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="69.029434"/>
+											<Node score="-0.015770774">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="65.70568"/>
+											</Node>
+										</Node>
+										<Node score="-0.011039855">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="53.546886"/>
+										</Node>
+									</Node>
+									<Node score="7.4414327E-4">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="67.77824"/>
+										<Node score="-0.0042790603">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.937714"/>
+											<Node score="-0.0071012704">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="60.22998"/>
+											</Node>
+										</Node>
+										<Node score="-0.0015884271">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="65.31964"/>
+										</Node>
+									</Node>
+									<Node score="0.003293652">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="72.6653"/>
+										<Node score="0.008224401">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="81.53046"/>
+										</Node>
+									</Node>
+									<Node score="0.008997196">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="76.32033"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="35">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q70_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.011001605">
+									<True/>
+									<Node score="-0.00913372">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.88912"/>
+										<Node score="-0.017306063">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="57.47844"/>
+											<Node score="-0.021437488">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="49.141685"/>
+												<Node score="-0.022724023">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="39.37851"/>
+												</Node>
+											</Node>
+											<Node score="-0.01937372">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="54.30801"/>
+											</Node>
+										</Node>
+										<Node score="-0.013170407">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="62.417522"/>
+											<Node score="-0.0152093265">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.73443"/>
+											</Node>
+										</Node>
+										<Node score="-0.0108397305">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.27926"/>
+										</Node>
+									</Node>
+									<Node score="8.2159904E-4">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="72.99931"/>
+										<Node score="-0.0029697379">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="68.14784"/>
+											<Node score="-0.0061547505">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="64.555786"/>
+											</Node>
+										</Node>
+										<Node score="0.005399828">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="72.82957"/>
+										</Node>
+									</Node>
+									<Node score="0.008062833">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="78.8282"/>
+										<Node score="0.0051407446">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="75.780975"/>
+										</Node>
+									</Node>
+									<Node score="0.01396819">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="82.99247"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="36">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q70_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.011345597">
+									<True/>
+									<Node score="-0.009128832">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="61.612595"/>
+										<Node score="-0.01722971">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="56.898014"/>
+											<Node score="-0.02116854">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="49.14716"/>
+												<Node score="-0.022528753">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="40.29021"/>
+												</Node>
+											</Node>
+											<Node score="-0.019166242">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="54.51061"/>
+											</Node>
+										</Node>
+										<Node score="-0.013355823">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.716633"/>
+											<Node score="-0.015375404">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.342915"/>
+											</Node>
+										</Node>
+										<Node score="-0.01094639">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.172485"/>
+										</Node>
+									</Node>
+									<Node score="-3.071085E-4">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="69.59617"/>
+										<Node score="-0.0045028077">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="65.17728"/>
+											<Node score="-0.006308989">
+												<SimplePredicate field="q70_age_Fname" operator="lessThan" value="64.410675"/>
+											</Node>
+										</Node>
+										<Node score="-0.0026142083">
+											<SimplePredicate field="q70_age_Fname" operator="lessThan" value="68.172485"/>
+										</Node>
+									</Node>
+									<Node score="0.0021788676">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="75.43053"/>
+										<Node score="0.009201425">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="73.20192"/>
+										</Node>
+									</Node>
+									<Node score="0.007583164">
+										<SimplePredicate field="q70_age_Fname" operator="lessThan" value="78.8282"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="37">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q80_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.012969226">
+									<True/>
+									<Node score="0.02816168">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.870636"/>
+										<Node score="-0.019251775">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="56.084873"/>
+											<Node score="-0.021062778">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="49.092403"/>
+												<Node score="-0.02235686">
+													<SimplePredicate field="q80_age_Fname" operator="lessThan" value="40.309376"/>
+												</Node>
+											</Node>
+											<Node score="-0.017152535">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="39.30185"/>
+											</Node>
+										</Node>
+										<Node score="-0.012969365">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.82341"/>
+											<Node score="-0.015197141">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="59.676933"/>
+											</Node>
+										</Node>
+										<Node score="-0.010252987">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="61.84531"/>
+										</Node>
+									</Node>
+									<Node score="1.989748E-4">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="63.77002"/>
+										<Node score="-0.0049953936">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="58.171116"/>
+											<Node score="-0.0074484926">
+												<SimplePredicate field="q80_age_Fname" operator="lessThan" value="68.24641"/>
+											</Node>
+										</Node>
+										<Node score="-0.0024110272">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="61.24846"/>
+										</Node>
+									</Node>
+									<Node score="0.006991804">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="69.59617"/>
+										<Node score="0.0034556452">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.01437"/>
+										</Node>
+									</Node>
+									<Node score="0.008848559">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="72.10404"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="38">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q60_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.0153643815">
+									<True/>
+									<Node score="-0.008835636">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="57.98768"/>
+										<Node score="-0.016302139">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="48.887062"/>
+											<Node score="-0.020374725">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="40.262833"/>
+												<Node score="-0.021545684">
+													<SimplePredicate field="q60_age_Fname" operator="lessThan" value="33.141685"/>
+												</Node>
+											</Node>
+											<Node score="-0.018314604">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="44.821354"/>
+											</Node>
+										</Node>
+										<Node score="-0.016527882">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="51.915127"/>
+											<Node score="-0.012018016">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="46.732376"/>
+											</Node>
+										</Node>
+										<Node score="-0.011099811">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="55.597534"/>
+										</Node>
+									</Node>
+									<Node score="0.0014550645">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.01574"/>
+										<Node score="-0.0040882076">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.833675"/>
+											<Node score="-0.006655232">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="60.21903"/>
+											</Node>
+										</Node>
+										<Node score="-0.0011791311">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="61.946613"/>
+										</Node>
+									</Node>
+									<Node score="0.0075452616">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="71.32922"/>
+										<Node score="0.0045349053">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.011578361">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="76.93087"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="39">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="median_age_Fname"/>
+									<MiningField name="q60_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.015202249">
+									<True/>
+									<Node score="-0.008646939">
+										<SimplePredicate field="q60_age_Fname" operator="lessThan" value="58.028748"/>
+										<Node score="-0.017901432">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="47.98631"/>
+											<Node score="-0.020461766">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="40.271046"/>
+												<Node score="-0.021825042">
+													<SimplePredicate field="q60_age_Fname" operator="lessThan" value="29.295004"/>
+												</Node>
+											</Node>
+											<Node score="-0.015224257">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="38.450375"/>
+											</Node>
+										</Node>
+										<Node score="-0.01673553">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="51.356606"/>
+											<Node score="-0.012759653">
+												<SimplePredicate field="median_age_Fname" operator="lessThan" value="46.086243"/>
+											</Node>
+										</Node>
+										<Node score="-0.011120877">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="55.701572"/>
+										</Node>
+									</Node>
+									<Node score="0.0014898186">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="65.02122"/>
+										<Node score="-0.0039463975">
+											<SimplePredicate field="q60_age_Fname" operator="lessThan" value="62.937714"/>
+											<Node score="-0.0065241302">
+												<SimplePredicate field="q60_age_Fname" operator="lessThan" value="60.22998"/>
+											</Node>
+										</Node>
+										<Node score="-0.0010971399">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="62.009583"/>
+										</Node>
+									</Node>
+									<Node score="0.007463704">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="71.26078"/>
+										<Node score="0.0044270703">
+											<SimplePredicate field="median_age_Fname" operator="lessThan" value="67.32375"/>
+										</Node>
+									</Node>
+									<Node score="0.011362049">
+										<SimplePredicate field="median_age_Fname" operator="lessThan" value="77.00479"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+						<Segment id="40">
+							<True/>
+							<TreeModel functionName="regression" noTrueChildStrategy="returnLastPrediction" x-mathContext="float">
+								<MiningSchema>
+									<MiningField name="q80_age_Fname"/>
+									<MiningField name="q90_age_Fname"/>
+								</MiningSchema>
+								<Node score="0.01136797">
+									<True/>
+									<Node score="-0.00978214">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="64.870636"/>
+										<Node score="-0.017712494">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="61.932922"/>
+											<Node score="-0.020899637">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="55.238876"/>
+												<Node score="-0.022023596">
+													<SimplePredicate field="q90_age_Fname" operator="lessThan" value="49.535934"/>
+												</Node>
+											</Node>
+											<Node score="-0.019439012">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="58.080765"/>
+											</Node>
+										</Node>
+										<Node score="-0.012522779">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="61.867214"/>
+											<Node score="-0.01497521">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="65.70568"/>
+											</Node>
+										</Node>
+										<Node score="0.0032843663">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="64.20534"/>
+										</Node>
+									</Node>
+									<Node score="-0.004334015">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="72.34497"/>
+										<Node score="-0.0072352006">
+											<SimplePredicate field="q80_age_Fname" operator="lessThan" value="68.02738"/>
+											<Node score="-0.0050527174">
+												<SimplePredicate field="q90_age_Fname" operator="lessThan" value="71.164955"/>
+											</Node>
+										</Node>
+										<Node score="-5.01026E-4">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="74.8282"/>
+										</Node>
+									</Node>
+									<Node score="9.836631E-4">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="77.82889"/>
+										<Node score="0.0073332842">
+											<SimplePredicate field="q90_age_Fname" operator="lessThan" value="77.17454"/>
+										</Node>
+									</Node>
+									<Node score="0.006425114">
+										<SimplePredicate field="q80_age_Fname" operator="lessThan" value="86.83915"/>
+									</Node>
+								</Node>
+							</TreeModel>
+						</Segment>
+					</Segmentation>
+				</MiningModel>
+			</Segment>
+			<Segment id="2">
+				<True/>
+				<RegressionModel functionName="classification" normalizationMethod="logit" x-mathContext="float">
+					<MiningSchema>
+						<MiningField name="_target" usageType="target"/>
+						<MiningField name="xgbValue"/>
+					</MiningSchema>
+					<Output>
+						<OutputField name="probability(0)" optype="continuous" dataType="float" feature="probability" value="0"/>
+						<OutputField name="probability(1)" optype="continuous" dataType="float" feature="probability" value="1"/>
+					</Output>
+					<RegressionTable intercept="0.0" targetCategory="1">
+						<NumericPredictor name="xgbValue" coefficient="1.0"/>
+					</RegressionTable>
+					<RegressionTable intercept="0.0" targetCategory="0"/>
+				</RegressionModel>
+			</Segment>
+		</Segmentation>
+	</MiningModel>
+</PMML>

--- a/unit_tests/contributions_fixture.hpp
+++ b/unit_tests/contributions_fixture.hpp
@@ -1,0 +1,94 @@
+// Expected per-feature contributions for XGBoostBinaryLogistic.pmml under the
+// path-attribution scheme defined in docs/adr/0002-path-attribution-for-tree-ensembles.md.
+//
+// Generated from the PMML by walking each tree and summing
+// (score[child] - score[parent]) per edge, attributed to the field tested in
+// child's predicate. __bias__ = base_score + sum_over_trees(score[root]).
+// Identity verified to 1e-9: raw_score == __bias__ + sum(contribs).
+//
+// To regenerate, see the spike walker in docs/adr/0002 or the original
+// session plan (xgb_model_F.json -> JPMML-XGBoost 1.9.8 -> this PMML).
+
+#ifndef contributions_fixture_hpp
+#define contributions_fixture_hpp
+
+#include <string>
+#include <vector>
+#include <map>
+
+namespace ContributionsFixture
+{
+    struct Case
+    {
+        std::map<std::string, double> input;
+        double raw_score;
+        double bias;
+        std::map<std::string, double> contribs;
+    };
+
+    // Three independent inputs covering low, mid, and high feature regimes.
+    inline std::vector<Case> xgboostBinaryLogisticCases()
+    {
+        return {
+            // Mid regime
+            {
+                {
+                    {"median_age_Fname", 35.0},
+                    {"q60_age_Fname",    40.0},
+                    {"q70_age_Fname",    45.0},
+                    {"q80_age_Fname",    50.0},
+                    {"q90_age_Fname",    60.0},
+                },
+                -0.9311254980,
+                 0.6628086100,
+                {
+                    {"median_age_Fname", -0.0986579635},
+                    {"q60_age_Fname",    -0.5739634920},
+                    {"q70_age_Fname",    -0.3375731070},
+                    {"q80_age_Fname",    -0.3819164500},
+                    {"q90_age_Fname",    -0.2018230955},
+                }
+            },
+            // Low regime
+            {
+                {
+                    {"median_age_Fname", 25.0},
+                    {"q60_age_Fname",    28.0},
+                    {"q70_age_Fname",    30.0},
+                    {"q80_age_Fname",    32.0},
+                    {"q90_age_Fname",    35.0},
+                },
+                -1.0430765570,
+                 0.6628086100,
+                {
+                    {"median_age_Fname", -0.1007572035},
+                    {"q60_age_Fname",    -0.5823167510},
+                    {"q70_age_Fname",    -0.3506323380},
+                    {"q80_age_Fname",    -0.4106187370},
+                    {"q90_age_Fname",    -0.2615601375},
+                }
+            },
+            // High regime
+            {
+                {
+                    {"median_age_Fname", 60.0},
+                    {"q60_age_Fname",    65.0},
+                    {"q70_age_Fname",    70.0},
+                    {"q80_age_Fname",    75.0},
+                    {"q90_age_Fname",    80.0},
+                },
+                -0.0320777458,
+                 0.6628086100,
+                {
+                    {"median_age_Fname", -0.3286692105},
+                    {"q60_age_Fname",    -0.2365791183},
+                    {"q70_age_Fname",    -0.0764787687},
+                    {"q80_age_Fname",    -0.0620421233},
+                    {"q90_age_Fname",     0.0088828650},
+                }
+            },
+        };
+    }
+}
+
+#endif

--- a/unit_tests/test_contributions.cpp
+++ b/unit_tests/test_contributions.cpp
@@ -36,10 +36,62 @@ namespace
         LuaOutputter::PRECEDENCE_TOP, Function::NEVER_MISSING
     };
 
-    lua_State * makeContributionsState()
+    struct RescaleParams
+    {
+        bool hasFactor = false;
+        double factor = 1.0;
+        bool hasConstant = false;
+        double constant = 0.0;
+    };
+
+    // Inject a <Targets><Target rescaleFactor=... rescaleConstant=.../></Targets>
+    // element into the inner regression MiningModel of the XGBoost fixture.
+    // Pamplemousse must apply the same linear transform to the score and to the
+    // contribution bias (and scale contributions when factor != 1) so the
+    // Saabas invariant `bias + sum(contribs) == score` keeps holding.
+    bool injectRescaleIntoXGBoostFixture(tinyxml2::XMLDocument & document, const RescaleParams & rescale)
+    {
+        if (!rescale.hasFactor && !rescale.hasConstant)
+        {
+            return true;
+        }
+
+        // Outer MiningModel -> Segmentation -> Segment[1] -> (predicate) -> inner MiningModel
+        auto outer = document.RootElement()->FirstChildElement("MiningModel");
+        if (!outer) return false;
+        auto outerSeg = outer->FirstChildElement("Segmentation");
+        if (!outerSeg) return false;
+        auto firstSegment = outerSeg->FirstChildElement("Segment");
+        if (!firstSegment) return false;
+        auto predicate = firstSegment->FirstChildElement(); // <True/> in this fixture
+        if (!predicate) return false;
+        auto innerMM = predicate->NextSiblingElement("MiningModel");
+        if (!innerMM) return false;
+
+        auto targets = document.NewElement("Targets");
+        auto target = document.NewElement("Target");
+        if (rescale.hasFactor)
+        {
+            target->SetAttribute("rescaleFactor", rescale.factor);
+        }
+        if (rescale.hasConstant)
+        {
+            target->SetAttribute("rescaleConstant", rescale.constant);
+        }
+        targets->InsertEndChild(target);
+        innerMM->InsertEndChild(targets);
+        return true;
+    }
+
+    lua_State * makeContributionsState(const RescaleParams & rescale = {})
     {
         tinyxml2::XMLDocument document;
         if (document.LoadFile(getPathToFile("XGBoostBinaryLogistic.pmml").c_str()) != tinyxml2::XML_SUCCESS)
+        {
+            return nullptr;
+        }
+
+        if (!injectRescaleIntoXGBoostFixture(document, rescale))
         {
             return nullptr;
         }
@@ -155,6 +207,99 @@ public:
         lua_close(L);
     }
 
+    // <Target rescaleConstant="X"/> shifts both the score output and the
+    // contribution bias by exactly X, leaving per-feature contributions
+    // unchanged. Without this fix in output.cpp::doTargetPostprocessing, the
+    // score-side gets the offset but the bias does not, silently breaking the
+    // Saabas invariant by exactly the rescaleConstant for any XGBoost model
+    // with a non-trivial base_score (which JPMML-XGBoost encodes as
+    // rescaleConstant).
+    void testRescaleConstantFoldedIntoBias()
+    {
+        const double constant = 7.5;
+        RescaleParams rescale;
+        rescale.hasConstant = true;
+        rescale.constant = constant;
+
+        lua_State * L = makeContributionsState(rescale);
+        CPPUNIT_ASSERT(L != nullptr);
+
+        for (const ContributionsFixture::Case & thisCase : ContributionsFixture::xgboostBinaryLogisticCases())
+        {
+            lua_getglobal(L, "func");
+            lua_pushnumber(L, thisCase.input.at("median_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q60_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q70_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q80_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q90_age_Fname"));
+            CPPUNIT_ASSERT_EQUAL(0, lua_pcall(L, 5, 2, 0));
+
+            const double rawScore = lua_tonumber(L, -2);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(thisCase.raw_score + constant, rawScore, 1e-6);
+            CPPUNIT_ASSERT(lua_istable(L, -1));
+
+            double sum = 0;
+            for (const auto & contribution : thisCase.contribs)
+            {
+                const double value = getTableNumber(L, contribution.first.c_str());
+                // Per-feature contributions are unchanged: rescaleConstant is
+                // additive on the score, not multiplicative.
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(contribution.second, value, 1e-6);
+                sum += value;
+            }
+
+            const double bias = getTableNumber(L, "__bias__");
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(thisCase.bias + constant, bias, 1e-6);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(rawScore, bias + sum, 1e-9);
+            lua_pop(L, 2);
+        }
+
+        lua_close(L);
+    }
+
+    // <Target rescaleFactor="F"/> scales the score, the bias, AND every
+    // per-feature contribution by F. Saabas invariant continues to hold.
+    void testRescaleFactorScalesContributions()
+    {
+        const double factor = 2.5;
+        RescaleParams rescale;
+        rescale.hasFactor = true;
+        rescale.factor = factor;
+
+        lua_State * L = makeContributionsState(rescale);
+        CPPUNIT_ASSERT(L != nullptr);
+
+        for (const ContributionsFixture::Case & thisCase : ContributionsFixture::xgboostBinaryLogisticCases())
+        {
+            lua_getglobal(L, "func");
+            lua_pushnumber(L, thisCase.input.at("median_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q60_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q70_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q80_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q90_age_Fname"));
+            CPPUNIT_ASSERT_EQUAL(0, lua_pcall(L, 5, 2, 0));
+
+            const double rawScore = lua_tonumber(L, -2);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(thisCase.raw_score * factor, rawScore, 1e-6);
+            CPPUNIT_ASSERT(lua_istable(L, -1));
+
+            double sum = 0;
+            for (const auto & contribution : thisCase.contribs)
+            {
+                const double value = getTableNumber(L, contribution.first.c_str());
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(contribution.second * factor, value, 1e-6);
+                sum += value;
+            }
+
+            const double bias = getTableNumber(L, "__bias__");
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(thisCase.bias * factor, bias, 1e-6);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(rawScore, bias + sum, 1e-9);
+            lua_pop(L, 2);
+        }
+
+        lua_close(L);
+    }
+
     void testUnsupportedMiningMethod()
     {
         tinyxml2::XMLDocument document;
@@ -179,6 +324,8 @@ public:
 
     CPPUNIT_TEST_SUITE(TestContributions);
     CPPUNIT_TEST(testXGBoostBinaryLogisticContributions);
+    CPPUNIT_TEST(testRescaleConstantFoldedIntoBias);
+    CPPUNIT_TEST(testRescaleFactorScalesContributions);
     CPPUNIT_TEST(testUnsupportedMiningMethod);
     CPPUNIT_TEST(testUnsupportedNonTreeModel);
     CPPUNIT_TEST_SUITE_END();

--- a/unit_tests/test_contributions.cpp
+++ b/unit_tests/test_contributions.cpp
@@ -83,19 +83,26 @@ namespace
         return true;
     }
 
-    lua_State * makeContributionsState(const RescaleParams & rescale = {})
+    double getTableNumber(lua_State * L, const char * key)
     {
-        tinyxml2::XMLDocument document;
-        if (document.LoadFile(getPathToFile("XGBoostBinaryLogistic.pmml").c_str()) != tinyxml2::XML_SUCCESS)
-        {
-            return nullptr;
-        }
+        lua_pushstring(L, key);
+        lua_gettable(L, -2);
+        const double out = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        return out;
+    }
 
-        if (!injectRescaleIntoXGBoostFixture(document, rescale))
-        {
-            return nullptr;
-        }
-
+    // Build a Lua function `func(<features...>)` that returns
+    // (raw_score, contribsTable) using the given PMML document. The
+    // contribsTable has a "__bias__" entry alongside per-feature contributions.
+    // `outputFieldName` must match the field convertPMML produces as the model's
+    // raw regression score (e.g. "xgbValue" for XGBoost-modelChain fixtures,
+    // "PredictedSepalLength" for the regression-average fixture, target field
+    // name for bare TreeModel).
+    lua_State * makeContributionsStateForDocument(tinyxml2::XMLDocument & document,
+                                                  const char * outputFieldName,
+                                                  const std::vector<const char *> & inputFeatures)
+    {
         AstBuilder builder;
         auto contributionsTable = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "__contributions__", PMMLDocument::ORIGIN_OUTPUT);
         auto biasAccumulator = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "__bias__", PMMLDocument::ORIGIN_OUTPUT);
@@ -118,7 +125,7 @@ namespace
         builder.constant("__bias__", PMMLDocument::TYPE_STRING);
         builder.assignIndirect(contributionsTable, 1);
 
-        auto rawScore = builder.context().getFieldDescription("xgbValue");
+        auto rawScore = builder.context().getFieldDescription(outputFieldName);
         if (!rawScore)
         {
             return nullptr;
@@ -134,15 +141,11 @@ namespace
         PMMLDocument::optimiseAST(astTree, output);
 
         output.function("func");
-        output.keyword("median_age_Fname");
-        output.comma();
-        output.keyword("q60_age_Fname");
-        output.comma();
-        output.keyword("q70_age_Fname");
-        output.comma();
-        output.keyword("q80_age_Fname");
-        output.comma();
-        output.keyword("q90_age_Fname");
+        for (size_t i = 0; i < inputFeatures.size(); ++i)
+        {
+            if (i > 0) output.comma();
+            output.keyword(inputFeatures[i]);
+        }
         output.finishedArguments();
         LuaConverter::convertAstToLua(astTree, output);
         output.endBlock();
@@ -158,13 +161,21 @@ namespace
         return L;
     }
 
-    double getTableNumber(lua_State * L, const char * key)
+    lua_State * makeContributionsState(const RescaleParams & rescale = {})
     {
-        lua_pushstring(L, key);
-        lua_gettable(L, -2);
-        const double out = lua_tonumber(L, -1);
-        lua_pop(L, 1);
-        return out;
+        tinyxml2::XMLDocument document;
+        if (document.LoadFile(getPathToFile("XGBoostBinaryLogistic.pmml").c_str()) != tinyxml2::XML_SUCCESS)
+        {
+            return nullptr;
+        }
+
+        if (!injectRescaleIntoXGBoostFixture(document, rescale))
+        {
+            return nullptr;
+        }
+
+        return makeContributionsStateForDocument(document, "xgbValue",
+            {"median_age_Fname", "q60_age_Fname", "q70_age_Fname", "q80_age_Fname", "q90_age_Fname"});
     }
 }
 
@@ -300,6 +311,136 @@ public:
         lua_close(L);
     }
 
+    // Verify the AVERAGE / WEIGHTEDAVERAGE multipleModelMethod paths in
+    // miningmodel.cpp::doRegressionSegments correctly merge per-segment
+    // contributions and divide by total weight. The Saabas invariant
+    // `predicted == bias + sum(contribs)` must hold.
+    void testWeightedAverageContributions()
+    {
+        tinyxml2::XMLDocument document;
+        CPPUNIT_ASSERT_EQUAL(tinyxml2::XML_SUCCESS,
+            document.LoadFile(getPathToFile("MiningModelRegressionAverage.pmml").c_str()));
+
+        // Make "continent" a numeric field so it can be passed positionally
+        // alongside the other doubles. The regression-average fixture splits on
+        // continent string values, but Pamplemousse's --contributions handles
+        // numeric splits in the trees we exercise here; for this test we don't
+        // visit any continent-based split, so we only need a placeholder value.
+        lua_State * L = makeContributionsStateForDocument(document, "PredictedSepalLength",
+            {"petal_length", "petal_width", "day", "continent", "sepal_width"});
+        CPPUNIT_ASSERT(L != nullptr);
+
+        struct AverageCase { double petal_length, petal_width, day, continent, sepal_width; };
+        const AverageCase cases[] = {
+            {2.0, 0.5, 100.0, 1.0, 3.0},
+            {5.5, 1.8, 200.0, 2.0, 3.4},
+            {4.2, 1.2, 150.0, 1.5, 2.9},
+        };
+
+        for (const auto & c : cases)
+        {
+            lua_getglobal(L, "func");
+            lua_pushnumber(L, c.petal_length);
+            lua_pushnumber(L, c.petal_width);
+            lua_pushnumber(L, c.day);
+            lua_pushnumber(L, c.continent);
+            lua_pushnumber(L, c.sepal_width);
+            CPPUNIT_ASSERT_EQUAL(0, lua_pcall(L, 5, 2, 0));
+
+            const double rawScore = lua_tonumber(L, -2);
+            CPPUNIT_ASSERT(lua_istable(L, -1));
+
+            // Sum every entry in the contribs table EXCEPT __bias__.
+            double sum = 0;
+            lua_pushnil(L);
+            while (lua_next(L, -2) != 0)
+            {
+                const char * key = lua_tostring(L, -2);
+                if (key && std::string(key) != "__bias__")
+                {
+                    sum += lua_tonumber(L, -1);
+                }
+                lua_pop(L, 1);
+            }
+
+            const double bias = getTableNumber(L, "__bias__");
+            // Saabas invariant: regression score equals bias plus per-feature
+            // contributions, summed across all weighted-average segments.
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(rawScore, bias + sum, 1e-6);
+            lua_pop(L, 2);
+        }
+
+        lua_close(L);
+    }
+
+    // Verify --contributions works for a bare <TreeModel> (no MiningModel
+    // wrapper). The bias-init path at model/treemodel.cpp seeds the bias
+    // accumulator with the root node's score; per-edge contributions accumulate
+    // as the tree is walked. Saabas invariant must hold.
+    void testBareTreeModelContributions()
+    {
+        tinyxml2::XMLDocument document;
+        CPPUNIT_ASSERT_EQUAL(tinyxml2::XML_SUCCESS,
+            document.LoadFile(getPathToFile("TreeNoTrueChild.pmml").c_str()));
+
+        // Default noTrueChildStrategy=returnNullPrediction would leave the
+        // result null when the input doesn't enter the explicit child, which is
+        // not interesting for path attribution. returnLastPrediction makes the
+        // tree always emit a value (the last node reached on the path) so we
+        // can verify the invariant cleanly.
+        tinyxml2::XMLElement * tree = document.RootElement()->FirstChildElement("TreeModel");
+        CPPUNIT_ASSERT(tree != nullptr);
+        tree->SetAttribute("noTrueChildStrategy", "returnLastPrediction");
+
+        // The fixture has no Output element; inject one so convertPMML produces
+        // a named output field we can grab from the generated Lua function.
+        tinyxml2::XMLElement * output = document.NewElement("Output");
+        tinyxml2::XMLElement * outputField = document.NewElement("OutputField");
+        outputField->SetAttribute("name", "predicted");
+        outputField->SetAttribute("feature", "predictedValue");
+        outputField->SetAttribute("dataType", "double");
+        outputField->SetAttribute("optype", "continuous");
+        output->InsertEndChild(outputField);
+        tree->InsertAfterChild(tree->FirstChildElement("MiningSchema"), output);
+
+        lua_State * L = makeContributionsStateForDocument(document, "predicted", {"prob1"});
+        CPPUNIT_ASSERT(L != nullptr);
+
+        // prob1 > 0.33: enters the child node (score=1). Saabas: bias=0 (root),
+        // contribs[prob1] = 1 - 0 = 1, total = 1.
+        {
+            lua_getglobal(L, "func");
+            lua_pushnumber(L, 0.5);
+            CPPUNIT_ASSERT_EQUAL(0, lua_pcall(L, 1, 2, 0));
+            const double rawScore = lua_tonumber(L, -2);
+            CPPUNIT_ASSERT(lua_istable(L, -1));
+            const double bias = getTableNumber(L, "__bias__");
+            const double prob1Contrib = getTableNumber(L, "prob1");
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, rawScore, 1e-9);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, bias, 1e-9);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, prob1Contrib, 1e-9);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(rawScore, bias + prob1Contrib, 1e-9);
+            lua_pop(L, 2);
+        }
+
+        // prob1 <= 0.33: returnLastPrediction returns the root's score (0).
+        // No contributions accumulated. Saabas: bias=0, no contribs, total=0.
+        {
+            lua_getglobal(L, "func");
+            lua_pushnumber(L, 0.1);
+            CPPUNIT_ASSERT_EQUAL(0, lua_pcall(L, 1, 2, 0));
+            const double rawScore = lua_tonumber(L, -2);
+            CPPUNIT_ASSERT(lua_istable(L, -1));
+            const double bias = getTableNumber(L, "__bias__");
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, rawScore, 1e-9);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, bias, 1e-9);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(rawScore, bias, 1e-9);
+            lua_pop(L, 2);
+        }
+
+        lua_close(L);
+    }
+
     void testUnsupportedMiningMethod()
     {
         tinyxml2::XMLDocument document;
@@ -326,6 +467,8 @@ public:
     CPPUNIT_TEST(testXGBoostBinaryLogisticContributions);
     CPPUNIT_TEST(testRescaleConstantFoldedIntoBias);
     CPPUNIT_TEST(testRescaleFactorScalesContributions);
+    CPPUNIT_TEST(testWeightedAverageContributions);
+    CPPUNIT_TEST(testBareTreeModelContributions);
     CPPUNIT_TEST(testUnsupportedMiningMethod);
     CPPUNIT_TEST(testUnsupportedNonTreeModel);
     CPPUNIT_TEST_SUITE_END();

--- a/unit_tests/test_contributions.cpp
+++ b/unit_tests/test_contributions.cpp
@@ -1,0 +1,185 @@
+//  Copyright 2018-2020 Lexis Nexis Risk Solutions
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "Cuti.h"
+
+#include "contributions_fixture.hpp"
+#include "document.hpp"
+#include "luaconverter/luaconverter.hpp"
+#include "luaconverter/luaoutputter.hpp"
+#include "luaconverter/optimiser.hpp"
+#include "testutils.hpp"
+
+#include <sstream>
+#include <vector>
+
+using namespace TestUtils;
+
+namespace
+{
+    const Function::Definition ReturnStatement =
+    {
+        nullptr,
+        Function::RETURN_STATEMENT,
+        PMMLDocument::TYPE_VOID,
+        LuaOutputter::PRECEDENCE_TOP, Function::NEVER_MISSING
+    };
+
+    lua_State * makeContributionsState()
+    {
+        tinyxml2::XMLDocument document;
+        if (document.LoadFile(getPathToFile("XGBoostBinaryLogistic.pmml").c_str()) != tinyxml2::XML_SUCCESS)
+        {
+            return nullptr;
+        }
+
+        AstBuilder builder;
+        auto contributionsTable = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "__contributions__", PMMLDocument::ORIGIN_OUTPUT);
+        auto biasAccumulator = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "__bias__", PMMLDocument::ORIGIN_OUTPUT);
+        PMMLDocument::ModelConfig config;
+        config.contributionsTable = contributionsTable;
+        config.biasAccumulator = biasAccumulator;
+        if (!PMMLDocument::convertPMML(builder, document.RootElement(), &config))
+        {
+            return nullptr;
+        }
+
+        AstNode model = builder.popNode();
+        builder.function(Function::makeTuple, 0);
+        builder.declare(contributionsTable, AstBuilder::HAS_INITIAL_VALUE);
+        builder.constant(0);
+        builder.declare(biasAccumulator, AstBuilder::HAS_INITIAL_VALUE);
+        builder.pushNode(std::move(model));
+
+        builder.field(biasAccumulator);
+        builder.constant("__bias__", PMMLDocument::TYPE_STRING);
+        builder.assignIndirect(contributionsTable, 1);
+
+        auto rawScore = builder.context().getFieldDescription("xgbValue");
+        if (!rawScore)
+        {
+            return nullptr;
+        }
+        builder.field(rawScore);
+        builder.field(contributionsTable);
+        builder.function(ReturnStatement, 2);
+        builder.block(builder.stackSize());
+
+        AstNode astTree = builder.popNode();
+        std::stringstream source;
+        LuaOutputter output(source);
+        PMMLDocument::optimiseAST(astTree, output);
+
+        output.function("func");
+        output.keyword("median_age_Fname");
+        output.comma();
+        output.keyword("q60_age_Fname");
+        output.comma();
+        output.keyword("q70_age_Fname");
+        output.comma();
+        output.keyword("q80_age_Fname");
+        output.comma();
+        output.keyword("q90_age_Fname");
+        output.finishedArguments();
+        LuaConverter::convertAstToLua(astTree, output);
+        output.endBlock();
+
+        lua_State * L = luaL_newstate();
+        luaL_openlibs(L);
+        if (luaL_dostring(L, source.str().c_str()))
+        {
+            fprintf(stderr, "%s\n", lua_tostring(L, -1));
+            lua_close(L);
+            return nullptr;
+        }
+        return L;
+    }
+
+    double getTableNumber(lua_State * L, const char * key)
+    {
+        lua_pushstring(L, key);
+        lua_gettable(L, -2);
+        const double out = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        return out;
+    }
+}
+
+TEST_CLASS (TestContributions)
+{
+public:
+    void testXGBoostBinaryLogisticContributions()
+    {
+        lua_State * L = makeContributionsState();
+        CPPUNIT_ASSERT(L != nullptr);
+
+        for (const ContributionsFixture::Case & thisCase : ContributionsFixture::xgboostBinaryLogisticCases())
+        {
+            lua_getglobal(L, "func");
+            lua_pushnumber(L, thisCase.input.at("median_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q60_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q70_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q80_age_Fname"));
+            lua_pushnumber(L, thisCase.input.at("q90_age_Fname"));
+            CPPUNIT_ASSERT_EQUAL(0, lua_pcall(L, 5, 2, 0));
+
+            const double rawScore = lua_tonumber(L, -2);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(thisCase.raw_score, rawScore, 1e-6);
+            CPPUNIT_ASSERT(lua_istable(L, -1));
+
+            double sum = 0;
+            for (const auto & contribution : thisCase.contribs)
+            {
+                const double value = getTableNumber(L, contribution.first.c_str());
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(contribution.second, value, 1e-6);
+                sum += value;
+            }
+
+            const double bias = getTableNumber(L, "__bias__");
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(thisCase.bias, bias, 1e-6);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(rawScore, bias + sum, 1e-9);
+            lua_pop(L, 2);
+        }
+
+        lua_close(L);
+    }
+
+    void testUnsupportedMiningMethod()
+    {
+        tinyxml2::XMLDocument document;
+        CPPUNIT_ASSERT_EQUAL(tinyxml2::XML_SUCCESS, document.LoadFile(getPathToFile("MiningModelMajority.pmml").c_str()));
+        AstBuilder builder;
+        PMMLDocument::ModelConfig config;
+        config.contributionsTable = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "__contributions__", PMMLDocument::ORIGIN_OUTPUT);
+        config.biasAccumulator = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "__bias__", PMMLDocument::ORIGIN_OUTPUT);
+        CPPUNIT_ASSERT(!PMMLDocument::convertPMML(builder, document.RootElement(), &config));
+    }
+
+    void testUnsupportedNonTreeModel()
+    {
+        tinyxml2::XMLDocument document;
+        CPPUNIT_ASSERT_EQUAL(tinyxml2::XML_SUCCESS, document.LoadFile(getPathToFile("SampleScorcard.pmml").c_str()));
+        AstBuilder builder;
+        PMMLDocument::ModelConfig config;
+        config.contributionsTable = builder.context().createVariable(PMMLDocument::TYPE_TABLE, "__contributions__", PMMLDocument::ORIGIN_OUTPUT);
+        config.biasAccumulator = builder.context().createVariable(PMMLDocument::TYPE_NUMBER, "__bias__", PMMLDocument::ORIGIN_OUTPUT);
+        CPPUNIT_ASSERT(!PMMLDocument::convertPMML(builder, document.RootElement(), &config));
+    }
+
+    CPPUNIT_TEST_SUITE(TestContributions);
+    CPPUNIT_TEST(testXGBoostBinaryLogisticContributions);
+    CPPUNIT_TEST(testUnsupportedMiningMethod);
+    CPPUNIT_TEST(testUnsupportedNonTreeModel);
+    CPPUNIT_TEST_SUITE_END();
+};


### PR DESCRIPTION
Adds a `--contributions` conversion mode that emits per-feature
path-attribution contributions alongside the score for tree models and
additive ensembles.


pamplemousse --convert --contributions feature_contribs model.pmml > model.lua


## How it works

For each tree, the generated Lua walks the decision path once and attributes
the delta `score[child] − score[parent]` to the field tested in the child's
predicate. A separate `__bias__` entry carries `base_score + Σ_trees score[root]`
so the additive (Saabas) identity holds exactly:


raw_score = bias + Σ contributions


This matches XGBoost's `predict(pred_contribs=True, approx_contribs=True)`
convention: contributions sum to the raw margin (pre-link), not the post-link
probability. Because common link functions (sigmoid, softmax) are monotonic,
feature ranking by `|contribution|` is preserved across the link — the property
reason-code / adverse-action use cases depend on.

## Scope

Supported for `TreeModel` and `MiningModel` whose `multipleModelMethod` is
`sum`, `weightedSum`, `average`, or `modelChain` wrapping one of those. For a
`modelChain` whose final link is a non-tree model (e.g. JPMML-XGBoost's logistic
wrapper), contributions accumulate against the inner ensemble's raw margin and
the link passes through. Any other model type or ensemble method hard-errors at
convert time when `--contributions` is set.

## Commits of note

- **Add `--contributions`** — core feature (codegen + per-model plumbing) with
  `test_contributions.cpp` and an XGBoost binary-logistic fixture.
- **Document `--contributions` in README.**
- **Use default origin for per-segment contribution scratch locals** — routes
  the per-tree contribution/bias locals through `ORIGIN_TEMPORARY` so the
  optimiser can spill them to an array. Fixes Lua's 200-locals-per-function
  limit on large ensembles (verified on a 124-feature, 1000-tree XGBoost model;
  generated Lua passes `luac -p`).
- **Apply Targets `rescaleConstant`/`rescaleFactor` to contribution bias** —
  mirrors the linear score post-transform onto the bias and contribution table
  so the Saabas invariant survives models with non-trivial `<Target>` (e.g.
  JPMML-XGBoost injecting `base_score`). Nonlinear ops
  (min/max/castInteger) intentionally do not propagate.
- **Tests** for rescaleConstant/Factor folding and for
  AVERAGE / WEIGHTEDAVERAGE / bare-TreeModel contributions.
- **Sandbox ForPairsLoop body assertions to a fresh local guard** — closes a
  latent optimiser footgun in the `ForPairsLoop` overload introduced by this
  branch (body may run zero times, so its non-none assertions must not leak).

## Verification

- Builds clean (`libpamplemousse_test`).
- Unit tests: `OK (55)`.

Depends on nothing else; the independent unit tests and the defaultChild
optimization were split out to #<unit-tests-PR>.